### PR TITLE
fix(gas): replace Map blobs with per-key persistent storage in escrow and rewards (#161)

### DIFF
--- a/contracts/teachlink/src/escrow.rs
+++ b/contracts/teachlink/src/escrow.rs
@@ -9,7 +9,7 @@ use crate::insurance::InsuranceManager;
 use crate::storage::{ESCROWS, ESCROW_COUNT};
 use crate::types::{DisputeOutcome, Escrow, EscrowApprovalKey, EscrowSigner, EscrowStatus};
 use crate::validation::EscrowValidator;
-use soroban_sdk::{symbol_short, vec, Address, Bytes, Env, IntoVal, Map, Vec};
+use soroban_sdk::{symbol_short, vec, Address, Bytes, Env, IntoVal, Vec};
 
 pub struct EscrowManager;
 
@@ -86,9 +86,9 @@ impl EscrowManager {
             dispute_reason: None,
         };
 
-        let mut escrows = Self::load_escrows(env);
-        escrows.set(escrow_count, escrow.clone());
-        env.storage().instance().set(&ESCROWS, &escrows);
+        env.storage()
+            .persistent()
+            .set(&(ESCROWS, escrow_count), &escrow);
 
         EscrowAnalyticsManager::update_creation(env, amount);
 
@@ -321,7 +321,7 @@ impl EscrowManager {
     // ---------- Views ----------
 
     pub fn get_escrow(env: &Env, escrow_id: u64) -> Option<Escrow> {
-        Self::load_escrows(env).get(escrow_id)
+        env.storage().persistent().get(&(ESCROWS, escrow_id))
     }
 
     pub fn get_escrow_count(env: &Env) -> u64 {
@@ -360,22 +360,17 @@ impl EscrowManager {
         *arbitrator == env.current_contract_address()
     }
 
-    fn load_escrows(env: &Env) -> Map<u64, Escrow> {
-        env.storage()
-            .instance()
-            .get(&ESCROWS)
-            .unwrap_or_else(|| Map::new(env))
-    }
-
     fn load_escrow(env: &Env, escrow_id: u64) -> Result<Escrow, EscrowError> {
-        let escrows = Self::load_escrows(env);
-        escrows.get(escrow_id).ok_or(EscrowError::EscrowNotFound)
+        env.storage()
+            .persistent()
+            .get(&(ESCROWS, escrow_id))
+            .ok_or(EscrowError::EscrowNotFound)
     }
 
     fn save_escrow(env: &Env, escrow_id: u64, escrow: Escrow) {
-        let mut escrows = Self::load_escrows(env);
-        escrows.set(escrow_id, escrow);
-        env.storage().instance().set(&ESCROWS, &escrows);
+        env.storage()
+            .persistent()
+            .set(&(ESCROWS, escrow_id), &escrow);
     }
 
     fn transfer_from_contract(env: &Env, token: &Address, to: &Address, amount: i128) {

--- a/contracts/teachlink/src/rewards.rs
+++ b/contracts/teachlink/src/rewards.rs
@@ -6,7 +6,7 @@ use crate::storage::{
 use crate::types::{RewardRate, UserReward};
 use crate::validation::RewardsValidator;
 
-use soroban_sdk::{symbol_short, vec, Address, Env, IntoVal, Map, String};
+use soroban_sdk::{symbol_short, vec, Address, Env, IntoVal, String};
 
 pub struct Rewards;
 
@@ -25,12 +25,6 @@ impl Rewards {
         env.storage().instance().set(&REWARDS_ADMIN, &rewards_admin);
         env.storage().instance().set(&REWARD_POOL, &0i128);
         env.storage().instance().set(&TOTAL_REWARDS_ISSUED, &0i128);
-
-        let reward_rates: Map<String, RewardRate> = Map::new(env);
-        env.storage().instance().set(&REWARD_RATES, &reward_rates);
-
-        let user_rewards: Map<Address, UserReward> = Map::new(env);
-        env.storage().instance().set(&USER_REWARDS, &user_rewards);
 
         Ok(())
     }
@@ -88,25 +82,24 @@ impl Rewards {
             return Err(RewardsError::InsufficientRewardPoolBalance);
         }
 
-        let mut user_rewards: Map<Address, UserReward> = env
+        let mut user_reward: UserReward = env
             .storage()
-            .instance()
-            .get(&USER_REWARDS)
-            .unwrap_or_else(|| Map::new(env));
-
-        let mut user_reward = user_rewards.get(recipient.clone()).unwrap_or(UserReward {
-            user: recipient.clone(),
-            total_earned: 0,
-            claimed: 0,
-            pending: 0,
-            last_claim_timestamp: 0,
-        });
+            .persistent()
+            .get(&(USER_REWARDS, recipient.clone()))
+            .unwrap_or(UserReward {
+                user: recipient.clone(),
+                total_earned: 0,
+                claimed: 0,
+                pending: 0,
+                last_claim_timestamp: 0,
+            });
 
         user_reward.total_earned += amount;
         user_reward.pending += amount;
 
-        user_rewards.set(recipient.clone(), user_reward);
-        env.storage().instance().set(&USER_REWARDS, &user_rewards);
+        env.storage()
+            .persistent()
+            .set(&(USER_REWARDS, recipient.clone()), &user_reward);
 
         let mut total_issued: i128 = env
             .storage()
@@ -136,14 +129,10 @@ impl Rewards {
     pub fn claim_rewards(env: &Env, user: Address) -> Result<(), RewardsError> {
         user.require_auth();
 
-        let mut user_rewards: Map<Address, UserReward> = env
+        let mut user_reward: UserReward = env
             .storage()
-            .instance()
-            .get(&USER_REWARDS)
-            .unwrap_or_else(|| Map::new(env));
-
-        let mut user_reward = user_rewards
-            .get(user.clone())
+            .persistent()
+            .get(&(USER_REWARDS, user.clone()))
             .ok_or(RewardsError::NoRewardsAvailable)?;
 
         if user_reward.pending <= 0 {
@@ -174,8 +163,9 @@ impl Rewards {
         user_reward.pending = 0;
         user_reward.last_claim_timestamp = env.ledger().timestamp();
 
-        user_rewards.set(user.clone(), user_reward);
-        env.storage().instance().set(&USER_REWARDS, &user_rewards);
+        env.storage()
+            .persistent()
+            .set(&(USER_REWARDS, user.clone()), &user_reward);
 
         let new_pool_balance = pool_balance - amount_to_claim;
         env.storage()
@@ -210,22 +200,14 @@ impl Rewards {
             return Err(RewardsError::RateCannotBeNegative);
         }
 
-        let mut reward_rates: Map<String, RewardRate> = env
-            .storage()
-            .instance()
-            .get(&REWARD_RATES)
-            .unwrap_or_else(|| Map::new(env));
-
-        reward_rates.set(
-            reward_type.clone(),
-            RewardRate {
+        env.storage().persistent().set(
+            &(REWARD_RATES, reward_type.clone()),
+            &RewardRate {
                 reward_type,
                 rate,
                 enabled,
             },
         );
-
-        env.storage().instance().set(&REWARD_RATES, &reward_rates);
 
         Ok(())
     }
@@ -242,12 +224,7 @@ impl Rewards {
     // ==========================
 
     pub fn get_user_rewards(env: &Env, user: Address) -> Option<UserReward> {
-        let user_rewards: Map<Address, UserReward> = env
-            .storage()
-            .instance()
-            .get(&USER_REWARDS)
-            .unwrap_or_else(|| Map::new(env));
-        user_rewards.get(user)
+        env.storage().persistent().get(&(USER_REWARDS, user))
     }
 
     pub fn get_reward_pool_balance(env: &Env) -> i128 {
@@ -262,12 +239,9 @@ impl Rewards {
     }
 
     pub fn get_reward_rate(env: &Env, reward_type: String) -> Option<RewardRate> {
-        let reward_rates: Map<String, RewardRate> = env
-            .storage()
-            .instance()
-            .get(&REWARD_RATES)
-            .unwrap_or_else(|| Map::new(env));
-        reward_rates.get(reward_type)
+        env.storage()
+            .persistent()
+            .get(&(REWARD_RATES, reward_type))
     }
 
     pub fn get_rewards_admin(env: &Env) -> Address {

--- a/contracts/teachlink/tests/test_gas_optimization.rs
+++ b/contracts/teachlink/tests/test_gas_optimization.rs
@@ -1,0 +1,321 @@
+#![cfg(test)]
+#![allow(clippy::needless_pass_by_value)]
+
+//! Tests verifying the gas-optimized storage patterns introduced in #161.
+//!
+//! The key optimizations verified here:
+//! - Escrows are stored per-key in persistent storage (not as a single Map blob).
+//! - User rewards and reward rates are stored per-key in persistent storage.
+//!
+//! Correct behaviour after the refactor is verified by:
+//! 1. Multiple escrows can be created and retrieved independently.
+//! 2. Updating one escrow does not affect another.
+//! 3. User rewards are isolated per address.
+//! 4. Reward rates are isolated per reward type.
+
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, testutils::Address as _, Address, Bytes, Env, Map, Vec,
+};
+
+use teachlink_contract::{
+    EscrowParameters, EscrowRole, EscrowSigner, EscrowStatus, TeachLinkBridge,
+    TeachLinkBridgeClient,
+};
+
+// ---------------------------------------------------------------------------
+// Minimal test token contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct GasTestToken;
+
+#[contractimpl]
+impl GasTestToken {
+    pub fn initialize(env: Env, admin: Address) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &admin);
+        let balances: Map<Address, i128> = Map::new(&env);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("bals"), &balances);
+    }
+
+    pub fn balance(env: Env, address: Address) -> i128 {
+        let balances: Map<Address, i128> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("bals"))
+            .unwrap_or_else(|| Map::new(&env));
+        balances.get(address).unwrap_or(0)
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        let mut balances: Map<Address, i128> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("bals"))
+            .unwrap_or_else(|| Map::new(&env));
+        let cur = balances.get(to.clone()).unwrap_or(0);
+        balances.set(to, cur + amount);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("bals"), &balances);
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let mut balances: Map<Address, i128> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("bals"))
+            .unwrap_or_else(|| Map::new(&env));
+        let from_bal = balances.get(from.clone()).unwrap_or(0);
+        assert!(from_bal >= amount, "Insufficient balance");
+        let to_bal = balances.get(to.clone()).unwrap_or(0);
+        balances.set(from, from_bal - amount);
+        balances.set(to, to_bal + amount);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("bals"), &balances);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn make_signer(env: &Env, addr: Address) -> EscrowSigner {
+    EscrowSigner {
+        address: addr,
+        role: EscrowRole::Primary,
+        weight: 1,
+    }
+}
+
+fn setup_env() -> (
+    Env,
+    TeachLinkBridgeClient<'static>,
+    GasTestTokenClient<'static>,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TeachLinkBridge, ());
+    let client = TeachLinkBridgeClient::new(&env, &contract_id);
+
+    let token_id = env.register(GasTestToken, ());
+    let token = GasTestTokenClient::new(&env, &token_id);
+
+    let admin = Address::generate(&env);
+    token.initialize(&admin);
+
+    // No insurance for these tests
+    client.initialize_insurance_pool(&token_id, &0);
+
+    (env, client, token, token_id)
+}
+
+// ---------------------------------------------------------------------------
+// Escrow per-key storage tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_two_escrows_stored_independently() {
+    let (env, client, token, token_id) = setup_env();
+
+    let depositor1 = Address::generate(&env);
+    let depositor2 = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+    let arb = Address::generate(&env);
+
+    token.mint(&depositor1, &1000);
+    token.mint(&depositor2, &1000);
+
+    let mut signers1 = Vec::new(&env);
+    signers1.push_back(make_signer(&env, signer1.clone()));
+
+    let mut signers2 = Vec::new(&env);
+    signers2.push_back(make_signer(&env, signer2.clone()));
+
+    let id1 = client.create_escrow(&EscrowParameters {
+        depositor: depositor1.clone(),
+        beneficiary: beneficiary.clone(),
+        token: token_id.clone(),
+        amount: 300,
+        signers: signers1,
+        threshold: 1,
+        release_time: None,
+        refund_time: None,
+        arbitrator: arb.clone(),
+    });
+
+    let id2 = client.create_escrow(&EscrowParameters {
+        depositor: depositor2.clone(),
+        beneficiary: beneficiary.clone(),
+        token: token_id.clone(),
+        amount: 500,
+        signers: signers2,
+        threshold: 1,
+        release_time: None,
+        refund_time: None,
+        arbitrator: arb.clone(),
+    });
+
+    // IDs are distinct
+    assert_ne!(id1, id2);
+
+    // Each escrow has its own amount stored correctly
+    let e1 = client.get_escrow(&id1).unwrap();
+    let e2 = client.get_escrow(&id2).unwrap();
+    assert_eq!(e1.amount, 300);
+    assert_eq!(e2.amount, 500);
+    assert_eq!(e1.depositor, depositor1);
+    assert_eq!(e2.depositor, depositor2);
+    assert_eq!(e1.status, EscrowStatus::Pending);
+    assert_eq!(e2.status, EscrowStatus::Pending);
+}
+
+#[test]
+fn test_releasing_one_escrow_does_not_affect_another() {
+    let (env, client, token, token_id) = setup_env();
+
+    let depositor = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let signer_a = Address::generate(&env);
+    let signer_b = Address::generate(&env);
+    let arb = Address::generate(&env);
+
+    token.mint(&depositor, &2000);
+
+    let mut signers_a = Vec::new(&env);
+    signers_a.push_back(make_signer(&env, signer_a.clone()));
+
+    let mut signers_b = Vec::new(&env);
+    signers_b.push_back(make_signer(&env, signer_b.clone()));
+
+    let id_a = client.create_escrow(&EscrowParameters {
+        depositor: depositor.clone(),
+        beneficiary: beneficiary.clone(),
+        token: token_id.clone(),
+        amount: 400,
+        signers: signers_a,
+        threshold: 1,
+        release_time: None,
+        refund_time: None,
+        arbitrator: arb.clone(),
+    });
+
+    let id_b = client.create_escrow(&EscrowParameters {
+        depositor: depositor.clone(),
+        beneficiary: beneficiary.clone(),
+        token: token_id.clone(),
+        amount: 600,
+        signers: signers_b,
+        threshold: 1,
+        release_time: None,
+        refund_time: None,
+        arbitrator: arb.clone(),
+    });
+
+    // Approve and release escrow A only
+    client.approve_escrow_release(&id_a, &signer_a);
+    client.release_escrow(&id_a, &signer_a);
+
+    let ea = client.get_escrow(&id_a).unwrap();
+    let eb = client.get_escrow(&id_b).unwrap();
+
+    assert_eq!(ea.status, EscrowStatus::Released);
+    // Escrow B must remain Pending — its storage slot is independent
+    assert_eq!(eb.status, EscrowStatus::Pending);
+}
+
+// ---------------------------------------------------------------------------
+// Rewards per-key storage tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_reward_rates_stored_per_type() {
+    let (env, client, token, token_id) = setup_env();
+
+    let rewards_admin = Address::generate(&env);
+    client.initialize_rewards(&token_id, &rewards_admin);
+
+    let type_a = soroban_sdk::String::from_str(&env, "course_complete");
+    let type_b = soroban_sdk::String::from_str(&env, "contribution");
+
+    client.set_reward_rate(&type_a, &100, &true);
+    client.set_reward_rate(&type_b, &250, &true);
+
+    let rate_a = client.get_reward_rate(&type_a).unwrap();
+    let rate_b = client.get_reward_rate(&type_b).unwrap();
+
+    assert_eq!(rate_a.rate, 100);
+    assert_eq!(rate_b.rate, 250);
+}
+
+#[test]
+fn test_user_rewards_isolated_per_address() {
+    let (env, client, token, token_id) = setup_env();
+
+    let rewards_admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let funder = Address::generate(&env);
+
+    client.initialize_rewards(&token_id, &rewards_admin);
+
+    // Fund the pool
+    token.mint(&funder, &10_000);
+    client.fund_reward_pool(&funder, &10_000);
+
+    let rtype = soroban_sdk::String::from_str(&env, "test");
+
+    client.issue_reward(&user_a, &300, &rtype);
+    client.issue_reward(&user_b, &700, &rtype);
+
+    let ra = client.get_user_rewards(&user_a).unwrap();
+    let rb = client.get_user_rewards(&user_b).unwrap();
+
+    // Each user's reward record is stored independently
+    assert_eq!(ra.pending, 300);
+    assert_eq!(rb.pending, 700);
+    assert_eq!(ra.total_earned, 300);
+    assert_eq!(rb.total_earned, 700);
+}
+
+#[test]
+fn test_issuing_reward_does_not_affect_other_user() {
+    let (env, client, token, token_id) = setup_env();
+
+    let rewards_admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let funder = Address::generate(&env);
+
+    client.initialize_rewards(&token_id, &rewards_admin);
+    token.mint(&funder, &10_000);
+    client.fund_reward_pool(&funder, &10_000);
+
+    let rtype = soroban_sdk::String::from_str(&env, "test");
+    client.issue_reward(&user_a, &500, &rtype);
+
+    // user_b has no rewards yet
+    let rb = client.get_user_rewards(&user_b);
+    assert!(rb.is_none());
+
+    // Issuing more to user_a does not corrupt user_b
+    client.issue_reward(&user_a, &200, &rtype);
+    let ra = client.get_user_rewards(&user_a).unwrap();
+    assert_eq!(ra.total_earned, 700);
+    assert_eq!(ra.pending, 700);
+}


### PR DESCRIPTION

Closes #161

Problem
escrow.rs stored all escrows as a single Map<u64, Escrow> in instance storage. Every escrow read or write — regardless of how many escrows exist — deserialized and re-serialized the entire map. The same pattern existed in rewards.rs for Map<Address, UserReward> and Map<String, RewardRate>. As state grows, transaction costs scale with total stored data, not just the entry being accessed.

Fix
Each escrow is now stored at its own persistent storage key (ESCROWS, escrow_id) — reads and writes touch only the single entry needed
Each user's reward record is stored at (USER_REWARDS, address) — independent per-user, no map round-trip
Each reward rate is stored at (REWARD_RATES, reward_type) — independent per type
Removed the load_escrows() helper that was the source of redundant full-map loads
Removed the initialization of empty Map blobs in initialize_rewards()
Tests
Added tests/test_gas_optimization.rs with 5 tests confirming per-key isolation: independent escrow slots, release isolation, reward rate isolation, user reward isolation, and cross-user reward independence