### PR TITLE
fix(time): reduce timestamp dependency in critical operations

### DIFF
--- a/contracts/teachlink/src/atomic_swap.rs
+++ b/contracts/teachlink/src/atomic_swap.rs
@@ -6,9 +6,9 @@
 use crate::errors::BridgeError;
 use crate::events::{SwapCompletedEvent, SwapInitiatedEvent, SwapRefundedEvent};
 use crate::reentrancy;
-use crate::storage::{ATOMIC_SWAPS, SWAP_COUNTER, SWAP_GUARD};
+use crate::storage::{ATOMIC_SWAPS, SWAP_COUNTER, SWAP_GUARD, SWAP_TIMELOCK_SEQ};
 use crate::types::{AtomicSwap, SwapStatus};
-use soroban_sdk::{symbol_short, vec, Address, Bytes, Env, IntoVal, Vec};
+use soroban_sdk::{symbol_short, vec, Address, Bytes, Env, IntoVal, Map, Vec};
 
 /// Minimum timelock duration (1 hour)
 pub const MIN_TIMELOCK: u64 = 3_600;
@@ -23,6 +23,21 @@ pub const HASH_LENGTH: u32 = 32;
 pub struct AtomicSwapManager;
 
 impl AtomicSwapManager {
+    fn timelock_expired(env: &Env, swap_id: u64, timelock_ts: u64) -> bool {
+        if env.ledger().timestamp() > timelock_ts {
+            return true;
+        }
+        let timelock_seq: Map<u64, u32> = env
+            .storage()
+            .instance()
+            .get(&SWAP_TIMELOCK_SEQ)
+            .unwrap_or_else(|| Map::new(env));
+        if let Some(seq_deadline) = timelock_seq.get(swap_id) {
+            return env.ledger().sequence() > seq_deadline;
+        }
+        false
+    }
+
     /// Initiate an atomic swap
     pub fn initiate_swap(
         env: &Env,
@@ -89,6 +104,21 @@ impl AtomicSwapManager {
             env.storage().instance().set(&ATOMIC_SWAPS, &swaps);
             env.storage().instance().set(&SWAP_COUNTER, &swap_counter);
 
+            // Store sequence-based deadline fallback.
+            let deadline_seq = env
+                .ledger()
+                .sequence()
+                .saturating_add(crate::ledger_time::seconds_to_ledger_delta(timelock));
+            let mut timelock_seq: soroban_sdk::Map<u64, u32> = env
+                .storage()
+                .instance()
+                .get(&SWAP_TIMELOCK_SEQ)
+                .unwrap_or_else(|| soroban_sdk::Map::new(env));
+            timelock_seq.set(swap_counter, deadline_seq);
+            env.storage()
+                .instance()
+                .set(&SWAP_TIMELOCK_SEQ, &timelock_seq);
+
             env.invoke_contract::<()>(
                 &initiator_token,
                 &symbol_short!("transfer"),
@@ -135,7 +165,7 @@ impl AtomicSwapManager {
                 return Err(BridgeError::SwapAlreadyCompleted);
             }
 
-            if env.ledger().timestamp() > swap.timelock {
+            if Self::timelock_expired(env, swap_id, swap.timelock) {
                 swap.status = SwapStatus::Expired;
                 swaps.set(swap_id, swap);
                 env.storage().instance().set(&ATOMIC_SWAPS, &swaps);
@@ -214,7 +244,7 @@ impl AtomicSwapManager {
             if swap.status == SwapStatus::Completed || swap.status == SwapStatus::Refunded {
                 return Err(BridgeError::SwapAlreadyCompleted);
             }
-            if env.ledger().timestamp() <= swap.timelock {
+            if !Self::timelock_expired(env, swap_id, swap.timelock) {
                 return Err(BridgeError::TimeoutNotReached);
             }
 
@@ -366,10 +396,31 @@ impl AtomicSwapManager {
 mod tests {
     use super::AtomicSwapManager;
     use crate::errors::BridgeError;
-    use crate::storage::SWAP_GUARD;
+    use crate::storage::{ATOMIC_SWAPS, SWAP_GUARD, SWAP_TIMELOCK_SEQ};
+    use crate::types::{AtomicSwap, SwapStatus};
     use crate::TeachLinkBridge;
     use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::Ledger;
+    use soroban_sdk::{contract, contractimpl};
     use soroban_sdk::{Address, Bytes, Env};
+
+    #[contract]
+    struct DummyToken;
+
+    #[contractimpl]
+    impl DummyToken {
+        #[allow(unused_variables)]
+        pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+            // no-op token stub for unit tests
+        }
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64, sequence: u32) {
+        env.ledger().with_mut(|li| {
+            li.timestamp = timestamp;
+            li.sequence_number = sequence;
+        });
+    }
 
     #[test]
     fn initiate_swap_rejects_when_reentrancy_guard_active() {
@@ -399,6 +450,53 @@ mod tests {
             );
 
             assert_eq!(result, Err(BridgeError::ReentrancyDetected));
+        });
+    }
+
+    #[test]
+    fn refund_swap_uses_sequence_fallback_when_timestamp_not_advanced() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+        let token_a = env.register(DummyToken, ());
+
+        env.as_contract(&contract_id, || {
+            let initiator = Address::generate(&env);
+            let counterparty = Address::generate(&env);
+            let token_b = Address::generate(&env);
+
+            set_ledger(&env, 1_000, 100);
+
+            let swap = AtomicSwap {
+                swap_id: 1,
+                initiator: initiator.clone(),
+                initiator_token: token_a,
+                initiator_amount: 100,
+                counterparty,
+                counterparty_token: token_b,
+                counterparty_amount: 100,
+                hashlock: Bytes::from_slice(&env, &[0xaa; 32]),
+                timelock: 2_000, // timestamp-based timelock not reached
+                status: SwapStatus::Initiated,
+                created_at: 1_000,
+            };
+
+            let mut swaps = soroban_sdk::Map::new(&env);
+            swaps.set(1u64, swap);
+            env.storage().instance().set(&ATOMIC_SWAPS, &swaps);
+
+            // Set sequence-based deadline already passed.
+            let mut seq_deadlines = soroban_sdk::Map::new(&env);
+            seq_deadlines.set(1u64, 101u32);
+            env.storage()
+                .instance()
+                .set(&SWAP_TIMELOCK_SEQ, &seq_deadlines);
+
+            // With timestamp-only logic this would be TimeoutNotReached; we now pass the check
+            // and proceed to the transfer invocation (stubbed).
+            set_ledger(&env, 1_000, 200);
+            let r = AtomicSwapManager::refund_swap(&env, 1, initiator);
+            assert_eq!(r, Ok(()));
         });
     }
 }

--- a/contracts/teachlink/src/bft_consensus.rs
+++ b/contracts/teachlink/src/bft_consensus.rs
@@ -9,8 +9,8 @@ use crate::events::{
     ValidatorUnregisteredEvent,
 };
 use crate::storage::{
-    BRIDGE_PROPOSALS, CONSENSUS_STATE, PROPOSAL_COUNTER, VALIDATORS, VALIDATOR_INFO,
-    VALIDATOR_STAKES,
+    BRIDGE_PROPOSALS, CONSENSUS_STATE, PROPOSAL_COUNTER, PROPOSAL_EXPIRES_SEQ, VALIDATORS,
+    VALIDATOR_ACTIVITY_SEQ, VALIDATOR_INFO, VALIDATOR_STAKES,
 };
 use crate::types::{
     BridgeProposal, ConsensusState, CrossChainMessage, ProposalStatus, ValidatorInfo,
@@ -72,6 +72,17 @@ impl BFTConsensus {
         env.storage()
             .instance()
             .set(&VALIDATOR_INFO, &validator_infos);
+
+        // Sequence-based activity fallback
+        let mut activity_seq: Map<Address, u32> = env
+            .storage()
+            .instance()
+            .get(&VALIDATOR_ACTIVITY_SEQ)
+            .unwrap_or_else(|| Map::new(env));
+        activity_seq.set(validator.clone(), env.ledger().sequence());
+        env.storage()
+            .instance()
+            .set(&VALIDATOR_ACTIVITY_SEQ, &activity_seq);
 
         // Store stake
         let mut stakes: Map<Address, i128> = env
@@ -206,6 +217,23 @@ impl BFTConsensus {
             .instance()
             .set(&PROPOSAL_COUNTER, &proposal_counter);
 
+        // Store sequence-based expiry fallback.
+        let expires_seq =
+            env.ledger()
+                .sequence()
+                .saturating_add(crate::ledger_time::seconds_to_ledger_delta(
+                    PROPOSAL_TIMEOUT,
+                ));
+        let mut proposal_expires_seq: Map<u64, u32> = env
+            .storage()
+            .instance()
+            .get(&PROPOSAL_EXPIRES_SEQ)
+            .unwrap_or_else(|| Map::new(env));
+        proposal_expires_seq.set(proposal_counter, expires_seq);
+        env.storage()
+            .instance()
+            .set(&PROPOSAL_EXPIRES_SEQ, &proposal_expires_seq);
+
         // Emit event
         ProposalCreatedEvent {
             proposal_id: proposal_counter,
@@ -247,7 +275,18 @@ impl BFTConsensus {
         }
 
         // Check if proposal has expired
-        if env.ledger().timestamp() > proposal.expires_at {
+        let mut expired = env.ledger().timestamp() > proposal.expires_at;
+        if !expired {
+            let proposal_expires_seq: Map<u64, u32> = env
+                .storage()
+                .instance()
+                .get(&PROPOSAL_EXPIRES_SEQ)
+                .unwrap_or_else(|| Map::new(env));
+            if let Some(expires_seq) = proposal_expires_seq.get(proposal_id) {
+                expired = env.ledger().sequence() > expires_seq;
+            }
+        }
+        if expired {
             proposal.status = ProposalStatus::Expired;
             proposals.set(proposal_id, proposal);
             env.storage().instance().set(&BRIDGE_PROPOSALS, &proposals);
@@ -394,6 +433,16 @@ impl BFTConsensus {
                 .set(&VALIDATOR_INFO, &validator_infos);
         }
 
+        let mut activity_seq: Map<Address, u32> = env
+            .storage()
+            .instance()
+            .get(&VALIDATOR_ACTIVITY_SEQ)
+            .unwrap_or_else(|| Map::new(env));
+        activity_seq.set(validator.clone(), env.ledger().sequence());
+        env.storage()
+            .instance()
+            .set(&VALIDATOR_ACTIVITY_SEQ, &activity_seq);
+
         Ok(())
     }
 
@@ -463,5 +512,63 @@ impl BFTConsensus {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BFTConsensus, MIN_VALIDATOR_STAKE, PROPOSAL_TIMEOUT};
+    use crate::errors::BridgeError;
+    use crate::storage::PROPOSAL_EXPIRES_SEQ;
+    use crate::types::CrossChainMessage;
+    use crate::TeachLinkBridge;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Bytes, Env, Map};
+
+    fn set_ledger(env: &Env, timestamp: u64, sequence: u32) {
+        env.ledger().with_mut(|li| {
+            li.timestamp = timestamp;
+            li.sequence_number = sequence;
+        });
+    }
+
+    #[test]
+    fn proposal_expiry_uses_sequence_fallback() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+
+        env.as_contract(&contract_id, || {
+            set_ledger(&env, 1_000, 1);
+
+            let validator = soroban_sdk::Address::generate(&env);
+            BFTConsensus::register_validator(&env, validator.clone(), MIN_VALIDATOR_STAKE).unwrap();
+
+            let msg = CrossChainMessage {
+                source_chain: 1,
+                source_tx_hash: Bytes::from_slice(&env, &[0x11; 32]),
+                nonce: 1,
+                token: soroban_sdk::Address::generate(&env),
+                amount: 1,
+                recipient: soroban_sdk::Address::generate(&env),
+                destination_chain: 2,
+                destination_address: Bytes::from_slice(&env, b"dest"),
+            };
+            let proposal_id = BFTConsensus::create_proposal(&env, msg).unwrap();
+
+            // Ensure the sequence-based expiry is stored.
+            let expires_seq: Map<u64, u32> =
+                env.storage().instance().get(&PROPOSAL_EXPIRES_SEQ).unwrap();
+            let deadline = expires_seq.get(proposal_id).unwrap();
+
+            // Keep timestamp constant but move sequence beyond the deadline.
+            // With timestamp-only logic, this would still be pending.
+            set_ledger(&env, 1_000, deadline.saturating_add(1));
+            let r = BFTConsensus::vote_on_proposal(&env, validator, proposal_id, true);
+            assert_eq!(r, Err(BridgeError::ProposalExpired));
+
+            // Sanity check constant is used (guards against accidental removal).
+            assert!(PROPOSAL_TIMEOUT > 0);
+        });
     }
 }

--- a/contracts/teachlink/src/bft_consensus.rs
+++ b/contracts/teachlink/src/bft_consensus.rs
@@ -517,11 +517,12 @@ impl BFTConsensus {
 
 #[cfg(test)]
 mod tests {
-    use super::{BFTConsensus, MIN_VALIDATOR_STAKE, PROPOSAL_TIMEOUT};
+    use super::{MIN_VALIDATOR_STAKE, PROPOSAL_TIMEOUT};
     use crate::errors::BridgeError;
     use crate::storage::PROPOSAL_EXPIRES_SEQ;
     use crate::types::CrossChainMessage;
     use crate::TeachLinkBridge;
+    use crate::TeachLinkBridgeClient;
     use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::{Bytes, Env, Map};
 
@@ -538,37 +539,41 @@ mod tests {
         env.mock_all_auths();
         let contract_id = env.register(TeachLinkBridge, ());
 
-        env.as_contract(&contract_id, || {
-            set_ledger(&env, 1_000, 1);
+        let client = TeachLinkBridgeClient::new(&env, &contract_id);
 
-            let validator = soroban_sdk::Address::generate(&env);
-            BFTConsensus::register_validator(&env, validator.clone(), MIN_VALIDATOR_STAKE).unwrap();
+        set_ledger(&env, 1_000, 1);
 
-            let msg = CrossChainMessage {
-                source_chain: 1,
-                source_tx_hash: Bytes::from_slice(&env, &[0x11; 32]),
-                nonce: 1,
-                token: soroban_sdk::Address::generate(&env),
-                amount: 1,
-                recipient: soroban_sdk::Address::generate(&env),
-                destination_chain: 2,
-                destination_address: Bytes::from_slice(&env, b"dest"),
-            };
-            let proposal_id = BFTConsensus::create_proposal(&env, msg).unwrap();
+        let validator = soroban_sdk::Address::generate(&env);
+        assert_eq!(
+            client.try_register_validator(&validator, &MIN_VALIDATOR_STAKE),
+            Ok(Ok(()))
+        );
 
-            // Ensure the sequence-based expiry is stored.
+        let msg = CrossChainMessage {
+            source_chain: 1,
+            source_tx_hash: Bytes::from_slice(&env, &[0x11; 32]),
+            nonce: 1,
+            token: soroban_sdk::Address::generate(&env),
+            amount: 1,
+            recipient: soroban_sdk::Address::generate(&env),
+            destination_chain: 2,
+        };
+        let proposal_id = client.try_create_bridge_proposal(&msg).unwrap().unwrap();
+
+        // Ensure the sequence-based expiry is stored.
+        let deadline = env.as_contract(&contract_id, || {
             let expires_seq: Map<u64, u32> =
                 env.storage().instance().get(&PROPOSAL_EXPIRES_SEQ).unwrap();
-            let deadline = expires_seq.get(proposal_id).unwrap();
-
-            // Keep timestamp constant but move sequence beyond the deadline.
-            // With timestamp-only logic, this would still be pending.
-            set_ledger(&env, 1_000, deadline.saturating_add(1));
-            let r = BFTConsensus::vote_on_proposal(&env, validator, proposal_id, true);
-            assert_eq!(r, Err(BridgeError::ProposalExpired));
-
-            // Sanity check constant is used (guards against accidental removal).
-            assert!(PROPOSAL_TIMEOUT > 0);
+            expires_seq.get(proposal_id).unwrap()
         });
+
+        // Keep timestamp constant but move sequence beyond the deadline.
+        // With timestamp-only logic, this would still be pending.
+        set_ledger(&env, 1_000, deadline.saturating_add(1));
+        let r = client.try_vote_on_proposal(&validator, &proposal_id, &true);
+        assert_eq!(r, Err(Ok(BridgeError::ProposalExpired)));
+
+        // Sanity check constant is used (guards against accidental removal).
+        assert!(PROPOSAL_TIMEOUT > 0);
     }
 }

--- a/contracts/teachlink/src/emergency.rs
+++ b/contracts/teachlink/src/emergency.rs
@@ -7,7 +7,7 @@ use crate::errors::BridgeError;
 use crate::events::{
     BridgePausedEvent, BridgeResumedEvent, CircuitBreakerResetEvent, CircuitBreakerTriggeredEvent,
 };
-use crate::storage::{CIRCUIT_BREAKERS, EMERGENCY_STATE, PAUSED_CHAINS};
+use crate::storage::{CIRCUIT_BREAKERS, CIRCUIT_RESET_SEQ, EMERGENCY_STATE, PAUSED_CHAINS};
 use crate::types::{CircuitBreaker, EmergencyState};
 use soroban_sdk::{Address, Bytes, Env, Map, Vec};
 
@@ -193,6 +193,14 @@ impl EmergencyManager {
             .instance()
             .set(&CIRCUIT_BREAKERS, &circuit_breakers);
 
+        let mut reset_seq: Map<u32, u32> = env
+            .storage()
+            .instance()
+            .get(&CIRCUIT_RESET_SEQ)
+            .unwrap_or_else(|| Map::new(env));
+        reset_seq.set(chain_id, env.ledger().sequence());
+        env.storage().instance().set(&CIRCUIT_RESET_SEQ, &reset_seq);
+
         Ok(())
     }
 
@@ -219,9 +227,34 @@ impl EmergencyManager {
 
         // Reset daily volume if needed
         let current_time = env.ledger().timestamp();
-        if current_time - breaker.last_reset >= DAILY_VOLUME_RESET {
+        let mut should_reset = current_time - breaker.last_reset >= DAILY_VOLUME_RESET;
+
+        // Fallback: sequence-based reset if timestamps are unreliable.
+        if !should_reset {
+            let reset_seq: Map<u32, u32> = env
+                .storage()
+                .instance()
+                .get(&CIRCUIT_RESET_SEQ)
+                .unwrap_or_else(|| Map::new(env));
+            if let Some(last_seq) = reset_seq.get(chain_id) {
+                let threshold_ledgers =
+                    crate::ledger_time::seconds_to_ledger_delta(DAILY_VOLUME_RESET);
+                should_reset =
+                    env.ledger().sequence().saturating_sub(last_seq) >= threshold_ledgers;
+            }
+        }
+
+        if should_reset {
             breaker.current_daily_volume = 0;
             breaker.last_reset = current_time;
+
+            let mut reset_seq: Map<u32, u32> = env
+                .storage()
+                .instance()
+                .get(&CIRCUIT_RESET_SEQ)
+                .unwrap_or_else(|| Map::new(env));
+            reset_seq.set(chain_id, env.ledger().sequence());
+            env.storage().instance().set(&CIRCUIT_RESET_SEQ, &reset_seq);
         }
 
         // Check transaction amount limit
@@ -300,6 +333,14 @@ impl EmergencyManager {
         env.storage()
             .instance()
             .set(&CIRCUIT_BREAKERS, &circuit_breakers);
+
+        let mut reset_seq: Map<u32, u32> = env
+            .storage()
+            .instance()
+            .get(&CIRCUIT_RESET_SEQ)
+            .unwrap_or_else(|| Map::new(env));
+        reset_seq.set(chain_id, env.ledger().sequence());
+        env.storage().instance().set(&CIRCUIT_RESET_SEQ, &reset_seq);
 
         // Emit event
         CircuitBreakerResetEvent {

--- a/contracts/teachlink/src/ledger_time.rs
+++ b/contracts/teachlink/src/ledger_time.rs
@@ -1,0 +1,22 @@
+//! Ledger time helpers
+//!
+//! Soroban `ledger().timestamp()` is not a monotonic wall-clock guarantee. For critical
+//! deadline checks, we also store and compare against `ledger().sequence()` as a fallback.
+
+use soroban_sdk::Env;
+
+/// Conservative estimate of seconds per ledger close on Stellar.
+///
+/// Used only to derive a *fallback* ledger-sequence deadline when code is otherwise
+/// timestamp-gated.
+pub const EST_SECS_PER_LEDGER: u64 = 5;
+
+pub fn seconds_to_ledger_delta(seconds: u64) -> u32 {
+    // Ceil division to avoid shortening timeouts.
+    let d = (seconds + EST_SECS_PER_LEDGER - 1) / EST_SECS_PER_LEDGER;
+    u32::try_from(d).unwrap_or(u32::MAX)
+}
+
+pub fn seq_now(env: &Env) -> u32 {
+    env.ledger().sequence()
+}

--- a/contracts/teachlink/src/lib.rs
+++ b/contracts/teachlink/src/lib.rs
@@ -105,6 +105,7 @@ mod event_query;
 mod events;
 mod insurance;
 mod interface_versioning;
+mod ledger_time;
 // FUTURE: Implement governance module (tracked in TRACKING.md)
 // mod governance;
 // mod learning_paths;

--- a/contracts/teachlink/src/slashing.rs
+++ b/contracts/teachlink/src/slashing.rs
@@ -8,8 +8,8 @@ use crate::events::{
     StakeDepositedEvent, StakeWithdrawnEvent, ValidatorRewardedEvent, ValidatorSlashedEvent,
 };
 use crate::storage::{
-    REWARD_POOL, SLASHING_COUNTER, SLASHING_RECORDS, VALIDATOR_INFO, VALIDATOR_REWARDS,
-    VALIDATOR_STAKES,
+    REWARD_POOL, SLASHING_COUNTER, SLASHING_RECORDS, VALIDATOR_ACTIVITY_SEQ, VALIDATOR_INFO,
+    VALIDATOR_REWARDS, VALIDATOR_STAKES,
 };
 use crate::types::{RewardType, SlashingReason, SlashingRecord, ValidatorInfo, ValidatorReward};
 use soroban_sdk::{Address, Env, Map, Vec};
@@ -310,8 +310,24 @@ impl SlashingManager {
             .unwrap_or_else(|| Map::new(env));
 
         if let Some(info) = validator_infos.get(validator.clone()) {
-            let inactive_duration = env.ledger().timestamp() - info.last_activity;
-            if inactive_duration > INACTIVITY_THRESHOLD {
+            let mut inactive =
+                (env.ledger().timestamp() - info.last_activity) > INACTIVITY_THRESHOLD;
+
+            // Sequence-based fallback for environments where timestamps are unreliable.
+            if !inactive {
+                let activity_seq: Map<Address, u32> = env
+                    .storage()
+                    .instance()
+                    .get(&VALIDATOR_ACTIVITY_SEQ)
+                    .unwrap_or_else(|| Map::new(env));
+                if let Some(last_seq) = activity_seq.get(validator.clone()) {
+                    let threshold_ledgers =
+                        crate::ledger_time::seconds_to_ledger_delta(INACTIVITY_THRESHOLD);
+                    inactive = env.ledger().sequence().saturating_sub(last_seq) > threshold_ledgers;
+                }
+            }
+
+            if inactive {
                 // Slash for inactivity
                 Self::slash_validator(
                     env,
@@ -388,5 +404,62 @@ impl SlashingManager {
             .get(&VALIDATOR_REWARDS)
             .unwrap_or_else(|| Map::new(env));
         rewards.get(validator).unwrap_or_else(|| Vec::new(env))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SlashingManager;
+    use crate::errors::BridgeError;
+    use crate::storage::{VALIDATOR_ACTIVITY_SEQ, VALIDATOR_INFO};
+    use crate::types::ValidatorInfo;
+    use crate::TeachLinkBridge;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, Env, Map};
+
+    fn set_ledger(env: &Env, timestamp: u64, sequence: u32) {
+        env.ledger().with_mut(|li| {
+            li.timestamp = timestamp;
+            li.sequence_number = sequence;
+        });
+    }
+
+    #[test]
+    fn inactivity_check_uses_sequence_fallback() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+
+        env.as_contract(&contract_id, || {
+            let validator = Address::generate(&env);
+
+            // Timestamp indicates activity is fresh.
+            set_ledger(&env, 1_000, 1);
+            let info = ValidatorInfo {
+                address: validator.clone(),
+                stake: 100,
+                reputation_score: 100,
+                is_active: true,
+                joined_at: 1_000,
+                last_activity: 1_000,
+                total_validations: 0,
+                missed_validations: 0,
+                slashed_amount: 0,
+            };
+            let mut infos: Map<Address, ValidatorInfo> = Map::new(&env);
+            infos.set(validator.clone(), info);
+            env.storage().instance().set(&VALIDATOR_INFO, &infos);
+
+            // Sequence says it's been a long time since last activity.
+            let mut seqs: Map<Address, u32> = Map::new(&env);
+            seqs.set(validator.clone(), 1u32);
+            env.storage().instance().set(&VALIDATOR_ACTIVITY_SEQ, &seqs);
+
+            // Advance sequence far beyond the fallback threshold.
+            set_ledger(&env, 1_000, 1_000_000);
+            let r = SlashingManager::check_inactivity(&env, validator);
+
+            assert_eq!(r, Ok(true));
+        });
     }
 }

--- a/contracts/teachlink/src/storage.rs
+++ b/contracts/teachlink/src/storage.rs
@@ -53,6 +53,12 @@ pub const EMERGENCY_STATE: Symbol = symbol_short!("emergency");
 pub const CIRCUIT_BREAKERS: Symbol = symbol_short!("circ_brk");
 pub const PAUSED_CHAINS: Symbol = symbol_short!("paused_ch");
 
+// Ledger-sequence based fallbacks for timestamp-gated critical paths
+pub const PROPOSAL_EXPIRES_SEQ: Symbol = symbol_short!("prp_exps");
+pub const VALIDATOR_ACTIVITY_SEQ: Symbol = symbol_short!("val_act");
+pub const SWAP_TIMELOCK_SEQ: Symbol = symbol_short!("sw_tmlk");
+pub const CIRCUIT_RESET_SEQ: Symbol = symbol_short!("cb_lrst");
+
 // Audit and Compliance Storage
 pub const AUDIT_RECORDS: Symbol = symbol_short!("audit_rec");
 pub const AUDIT_COUNTER: Symbol = symbol_short!("audit_cnt");


### PR DESCRIPTION
Summary
- Add ledger-sequence fallback deadlines for timestamp-gated operations
- Store sequence-based expiry for proposals and atomic swaps
- Add sequence fallback for validator inactivity and circuit breaker daily resets

Implementation
- New helper: contracts/teachlink/src/ledger_time.rs
- New storage maps: PROPOSAL_EXPIRES_SEQ, VALIDATOR_ACTIVITY_SEQ, SWAP_TIMELOCK_SEQ, CIRCUIT_RESET_SEQ

Tests
- Added unit tests covering sequence fallback for proposal expiry and swap refund

Notes
- Local full test run was blocked by disk exhaustion in this environment; changes are unit-tested where possible and rely on existing CI for full coverage.

Closes #252