### PR TITLE
fix: multi-sig validation edge cases

### DIFF
--- a/contracts/teachlink/src/validation.rs
+++ b/contracts/teachlink/src/validation.rs
@@ -296,10 +296,13 @@ impl EscrowValidator {
 
         let mut total_weight: u32 = 0;
         for signer in signers.iter() {
+            if signer.weight == 0 {
+                return Err(EscrowError::InvalidSignerThreshold);
+            }
             total_weight += signer.weight;
         }
 
-        if threshold < 1 || threshold > total_weight {
+        if threshold < 1 || total_weight == 0 || threshold > total_weight {
             return Err(EscrowError::InvalidSignerThreshold);
         }
 
@@ -318,8 +321,14 @@ impl EscrowValidator {
 
     /// Checks for duplicate signers in the list
     pub fn check_duplicate_signers(signers: &Vec<EscrowSigner>) -> Result<(), EscrowError> {
-        // Simplified check - removed Env::current() call which doesn't exist
-        // This validation is now handled by the caller
+        let len = signers.len();
+        for i in 0..len {
+            for j in (i + 1)..len {
+                if signers.get(i).unwrap().address == signers.get(j).unwrap().address {
+                    return Err(EscrowError::DuplicateSigner);
+                }
+            }
+        }
         Ok(())
     }
 
@@ -348,10 +357,13 @@ impl EscrowValidator {
         // Validate threshold against total signer weight
         let mut total_weight: u32 = 0;
         for signer in params.signers.iter() {
+            if signer.weight == 0 {
+                return Err(EscrowError::InvalidSignerThreshold);
+            }
             total_weight += signer.weight;
         }
 
-        if params.threshold < 1 || params.threshold > total_weight {
+        if params.threshold < 1 || total_weight == 0 || params.threshold > total_weight {
             return Err(EscrowError::InvalidSignerThreshold);
         }
 


### PR DESCRIPTION
Fix multi-signature validation edge cases                                                      
                                                                                                 
  Addresses three vulnerabilities in the multi-sig validation logic:                             
                                                                                                 
  - Duplicate signature
  - s: check_duplicate_signers was a stub that always returned Ok(()). Now    
  performs address comparison across all signer pairs and returns DuplicateSigner on any         
  duplicate.                                                                                     
  - Weight validation: Signers with weight == 0 are now explicitly rejected with                 
  InvalidSignerThreshold, preventing zero-weight signers from inflating the signer count without 
  contributing to approval weight.                                                               
  - Threshold boundaries: Added a total_weight == 0 guard to prevent a bypass where              
  all-zero-weight signers could pass the threshold check.                                        
                                                                                                 
  Files changed: contracts/teachlink/src/validation.rs  
 closes #249
