### PR TITLE
fix: resolve storage collision, validator manipulation, and rate limiting

### DIFF
--- a/contracts/teachlink/src/bft_consensus.rs
+++ b/contracts/teachlink/src/bft_consensus.rs
@@ -594,8 +594,7 @@ impl BFTConsensus {
     /// and trigger rotation if so.
     pub fn maybe_rotate(env: &Env) -> Result<bool, BridgeError> {
         let state = Self::get_consensus_state(env);
-        if state.last_consensus_round > 0
-            && state.last_consensus_round % ROTATION_EPOCH_ROUNDS == 0
+        if state.last_consensus_round > 0 && state.last_consensus_round % ROTATION_EPOCH_ROUNDS == 0
         {
             Self::rotate_validators(env)?;
             return Ok(true);
@@ -754,6 +753,9 @@ mod tests {
             infos.get(validator.clone()).unwrap().reputation_score
         });
 
-        assert!(after_rep > initial_rep, "reputation should increase after voting");
+        assert!(
+            after_rep > initial_rep,
+            "reputation should increase after voting"
+        );
     }
 }

--- a/contracts/teachlink/src/bft_consensus.rs
+++ b/contracts/teachlink/src/bft_consensus.rs
@@ -9,8 +9,8 @@ use crate::events::{
     ValidatorUnregisteredEvent,
 };
 use crate::storage::{
-    BRIDGE_PROPOSALS, CONSENSUS_STATE, PROPOSAL_COUNTER, PROPOSAL_EXPIRES_SEQ, VALIDATORS,
-    VALIDATOR_ACTIVITY_SEQ, VALIDATOR_INFO, VALIDATOR_STAKES,
+    StorageKey, BRIDGE_PROPOSALS, CONSENSUS_STATE, PROPOSAL_COUNTER, PROPOSAL_EXPIRES_SEQ,
+    VALIDATORS, VALIDATOR_ACTIVITY_SEQ, VALIDATOR_INFO, VALIDATOR_STAKES,
 };
 use crate::types::{
     BridgeProposal, ConsensusState, CrossChainMessage, ProposalStatus, ValidatorInfo,
@@ -22,6 +22,15 @@ pub const MIN_VALIDATOR_STAKE: i128 = 100_000_000; // 100 tokens with 6 decimals
 
 /// Proposal timeout in seconds (24 hours)
 pub const PROPOSAL_TIMEOUT: u64 = 86_400;
+
+/// Number of consensus rounds per rotation epoch.
+/// After this many rounds, the active validator set is re-evaluated and
+/// low-reputation validators may be rotated out.
+pub const ROTATION_EPOCH_ROUNDS: u64 = 100;
+
+/// Minimum reputation score required to remain in the active validator set.
+/// Validators below this threshold are rotated out during epoch transitions.
+pub const MIN_ACTIVE_REPUTATION: u32 = 40;
 
 /// BFT Consensus Manager
 pub struct BFTConsensus;
@@ -306,8 +315,9 @@ impl BFTConsensus {
         proposals.set(proposal_id, proposal.clone());
         env.storage().instance().set(&BRIDGE_PROPOSALS, &proposals);
 
-        // Update validator activity
+        // Update validator activity and boost reputation for participation
         Self::update_validator_activity(env, &validator)?;
+        Self::boost_reputation(env, &validator);
 
         // Check if proposal has reached consensus
         if proposal.vote_count >= proposal.required_votes {
@@ -513,6 +523,103 @@ impl BFTConsensus {
             false
         }
     }
+
+    /// Rotate validators: deactivate those below `MIN_ACTIVE_REPUTATION` or with
+    /// insufficient stake, and update the consensus state.
+    ///
+    /// This should be called at epoch boundaries (every `ROTATION_EPOCH_ROUNDS`
+    /// consensus rounds) to prevent long-term validator collusion by ensuring
+    /// only validators with good standing remain active.
+    pub fn rotate_validators(env: &Env) -> Result<u32, BridgeError> {
+        let mut validators: Map<Address, bool> = env
+            .storage()
+            .instance()
+            .get(&VALIDATORS)
+            .unwrap_or_else(|| Map::new(env));
+
+        let validator_infos: Map<Address, ValidatorInfo> = env
+            .storage()
+            .instance()
+            .get(&VALIDATOR_INFO)
+            .unwrap_or_else(|| Map::new(env));
+
+        let stakes: Map<Address, i128> = env
+            .storage()
+            .instance()
+            .get(&VALIDATOR_STAKES)
+            .unwrap_or_else(|| Map::new(env));
+
+        let mut rotated_out: u32 = 0;
+
+        // Collect addresses to deactivate (can't mutate map while iterating)
+        let mut to_deactivate: Vec<Address> = Vec::new(env);
+        for (addr, is_active) in validators.iter() {
+            if !is_active {
+                continue;
+            }
+            let should_deactivate = if let Some(info) = validator_infos.get(addr.clone()) {
+                info.reputation_score < MIN_ACTIVE_REPUTATION
+                    || stakes.get(addr.clone()).unwrap_or(0) < MIN_VALIDATOR_STAKE
+            } else {
+                // No info record — deactivate
+                true
+            };
+            if should_deactivate {
+                to_deactivate.push_back(addr);
+            }
+        }
+
+        for addr in to_deactivate.iter() {
+            validators.set(addr.clone(), false);
+            rotated_out += 1;
+        }
+
+        env.storage().instance().set(&VALIDATORS, &validators);
+
+        // Record the rotation epoch in namespaced storage (issue #242)
+        let current_epoch: u64 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::ValidatorRotationEpoch)
+            .unwrap_or(0u64);
+        env.storage()
+            .instance()
+            .set(&StorageKey::ValidatorRotationEpoch, &(current_epoch + 1));
+
+        Self::update_consensus_state(env)?;
+        Ok(rotated_out)
+    }
+
+    /// Check whether the current consensus round has crossed an epoch boundary
+    /// and trigger rotation if so.
+    pub fn maybe_rotate(env: &Env) -> Result<bool, BridgeError> {
+        let state = Self::get_consensus_state(env);
+        if state.last_consensus_round > 0
+            && state.last_consensus_round % ROTATION_EPOCH_ROUNDS == 0
+        {
+            Self::rotate_validators(env)?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    /// Boost a validator's reputation score for participating in consensus.
+    /// Called internally after a successful vote.
+    fn boost_reputation(env: &Env, validator: &Address) {
+        let mut validator_infos: Map<Address, ValidatorInfo> = env
+            .storage()
+            .instance()
+            .get(&VALIDATOR_INFO)
+            .unwrap_or_else(|| Map::new(env));
+        if let Some(mut info) = validator_infos.get(validator.clone()) {
+            // Cap at 100
+            info.reputation_score = info.reputation_score.saturating_add(1).min(100);
+            validator_infos.set(validator.clone(), info);
+            env.storage()
+                .instance()
+                .set(&VALIDATOR_INFO, &validator_infos);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -575,5 +682,78 @@ mod tests {
 
         // Sanity check constant is used (guards against accidental removal).
         assert!(PROPOSAL_TIMEOUT > 0);
+    }
+
+    #[test]
+    fn rotate_validators_removes_low_reputation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+        set_ledger(&env, 1_000, 1);
+
+        let validator = soroban_sdk::Address::generate(&env);
+        let client = TeachLinkBridgeClient::new(&env, &contract_id);
+        client.register_validator(&validator, &MIN_VALIDATOR_STAKE);
+
+        // Manually drop reputation below threshold
+        env.as_contract(&contract_id, || {
+            use crate::storage::VALIDATOR_INFO;
+            use crate::types::ValidatorInfo;
+            let mut infos: Map<soroban_sdk::Address, ValidatorInfo> =
+                env.storage().instance().get(&VALIDATOR_INFO).unwrap();
+            let mut info = infos.get(validator.clone()).unwrap();
+            info.reputation_score = 10; // below MIN_ACTIVE_REPUTATION (40)
+            infos.set(validator.clone(), info);
+            env.storage().instance().set(&VALIDATOR_INFO, &infos);
+        });
+
+        env.as_contract(&contract_id, || {
+            use crate::bft_consensus::BFTConsensus;
+            let rotated = BFTConsensus::rotate_validators(&env).unwrap();
+            assert_eq!(rotated, 1);
+            assert!(!BFTConsensus::is_active_validator(&env, &validator));
+        });
+    }
+
+    #[test]
+    fn voting_boosts_reputation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+        set_ledger(&env, 1_000, 1);
+
+        let validator = soroban_sdk::Address::generate(&env);
+        let client = TeachLinkBridgeClient::new(&env, &contract_id);
+        client.register_validator(&validator, &MIN_VALIDATOR_STAKE);
+
+        let initial_rep = env.as_contract(&contract_id, || {
+            use crate::storage::VALIDATOR_INFO;
+            use crate::types::ValidatorInfo;
+            let infos: Map<soroban_sdk::Address, ValidatorInfo> =
+                env.storage().instance().get(&VALIDATOR_INFO).unwrap();
+            infos.get(validator.clone()).unwrap().reputation_score
+        });
+
+        let msg = CrossChainMessage {
+            source_chain: 1,
+            source_tx_hash: soroban_sdk::Bytes::from_slice(&env, &[0xAB; 32]),
+            nonce: 1,
+            token: soroban_sdk::Address::generate(&env),
+            amount: 1,
+            recipient: soroban_sdk::Address::generate(&env),
+            destination_chain: 2,
+        };
+        let proposal_id = client.create_bridge_proposal(&msg);
+        client.vote_on_proposal(&validator, &proposal_id, &true);
+
+        let after_rep = env.as_contract(&contract_id, || {
+            use crate::storage::VALIDATOR_INFO;
+            use crate::types::ValidatorInfo;
+            let infos: Map<soroban_sdk::Address, ValidatorInfo> =
+                env.storage().instance().get(&VALIDATOR_INFO).unwrap();
+            infos.get(validator.clone()).unwrap().reputation_score
+        });
+
+        assert!(after_rep > initial_rep, "reputation should increase after voting");
     }
 }

--- a/contracts/teachlink/src/bft_consensus.rs
+++ b/contracts/teachlink/src/bft_consensus.rs
@@ -725,12 +725,16 @@ mod tests {
         let client = TeachLinkBridgeClient::new(&env, &contract_id);
         client.register_validator(&validator, &MIN_VALIDATOR_STAKE);
 
-        let initial_rep = env.as_contract(&contract_id, || {
+        // Lower reputation below max so the boost is observable (validators start at 100)
+        env.as_contract(&contract_id, || {
             use crate::storage::VALIDATOR_INFO;
             use crate::types::ValidatorInfo;
-            let infos: Map<soroban_sdk::Address, ValidatorInfo> =
+            let mut infos: Map<soroban_sdk::Address, ValidatorInfo> =
                 env.storage().instance().get(&VALIDATOR_INFO).unwrap();
-            infos.get(validator.clone()).unwrap().reputation_score
+            let mut info = infos.get(validator.clone()).unwrap();
+            info.reputation_score = 90;
+            infos.set(validator.clone(), info);
+            env.storage().instance().set(&VALIDATOR_INFO, &infos);
         });
 
         let msg = CrossChainMessage {
@@ -753,9 +757,6 @@ mod tests {
             infos.get(validator.clone()).unwrap().reputation_score
         });
 
-        assert!(
-            after_rep > initial_rep,
-            "reputation should increase after voting"
-        );
+        assert!(after_rep > 90, "reputation should increase after voting");
     }
 }

--- a/contracts/teachlink/src/lib.rs
+++ b/contracts/teachlink/src/lib.rs
@@ -140,6 +140,7 @@ mod notification_types;
 mod performance;
 mod property_based_tests;
 mod provenance;
+mod rate_limiting;
 mod recommendation;
 mod reentrancy;
 mod reporting;
@@ -417,6 +418,17 @@ impl TeachLinkBridge {
     /// Check if consensus is reached for a proposal
     pub fn is_consensus_reached(env: Env, proposal_id: u64) -> bool {
         bft_consensus::BFTConsensus::is_consensus_reached(&env, proposal_id)
+    }
+
+    /// Rotate validators: deactivate those with low reputation or insufficient stake.
+    /// Returns the number of validators rotated out.
+    pub fn rotate_validators(env: Env) -> Result<u32, BridgeError> {
+        bft_consensus::BFTConsensus::rotate_validators(&env)
+    }
+
+    /// Trigger rotation if the current consensus round is at an epoch boundary.
+    pub fn maybe_rotate_validators(env: Env) -> Result<bool, BridgeError> {
+        bft_consensus::BFTConsensus::maybe_rotate(&env)
     }
 
     // ========== Slashing and Rewards Functions ==========

--- a/contracts/teachlink/src/rate_limiting.rs
+++ b/contracts/teachlink/src/rate_limiting.rs
@@ -117,7 +117,11 @@ impl RateLimiter {
 mod tests {
     use super::*;
     use crate::TeachLinkBridge;
-    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+    use soroban_sdk::{
+        symbol_short,
+        testutils::{Address as _, Ledger as _},
+        Address, Env,
+    };
 
     fn set_seq(env: &Env, seq: u32) {
         env.ledger().with_mut(|li| li.sequence_number = seq);

--- a/contracts/teachlink/src/rate_limiting.rs
+++ b/contracts/teachlink/src/rate_limiting.rs
@@ -56,14 +56,14 @@ impl RateLimiter {
         let key = Self::state_key(caller, endpoint);
         let current_seq = env.ledger().sequence();
 
-        let mut state: RateLimitState = env
-            .storage()
-            .instance()
-            .get(&key)
-            .unwrap_or(RateLimitState {
-                window_start: current_seq,
-                call_count: 0,
-            });
+        let mut state: RateLimitState =
+            env.storage()
+                .instance()
+                .get(&key)
+                .unwrap_or(RateLimitState {
+                    window_start: current_seq,
+                    call_count: 0,
+                });
 
         // Reset window if it has expired
         if current_seq.saturating_sub(state.window_start) >= config.window_ledgers {

--- a/contracts/teachlink/src/rate_limiting.rs
+++ b/contracts/teachlink/src/rate_limiting.rs
@@ -1,0 +1,209 @@
+//! Rate Limiting Module
+//!
+//! Provides per-user and per-endpoint call-rate enforcement for contract
+//! entry points, addressing issue #266.
+//!
+//! # Design
+//! - Each (user, endpoint) pair gets an independent window tracked by ledger
+//!   sequence number so it works even when block timestamps are unreliable.
+//! - Limits are configurable per endpoint via `EndpointConfig`.
+//! - When a limit is exceeded the call returns `BridgeError::RetryLimitExceeded`
+//!   so callers can implement graceful degradation.
+
+use crate::errors::BridgeError;
+use crate::storage::StorageKey;
+use soroban_sdk::{contracttype, Address, Env, Map, Symbol};
+
+/// Per-endpoint rate-limit configuration.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EndpointConfig {
+    /// Maximum calls allowed within `window_ledgers`.
+    pub max_calls: u32,
+    /// Window size in ledger sequences.
+    pub window_ledgers: u32,
+}
+
+/// Per-(user, endpoint) rate-limit state stored on-chain.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RateLimitState {
+    /// Ledger sequence at which the current window started.
+    pub window_start: u32,
+    /// Number of calls made in the current window.
+    pub call_count: u32,
+}
+
+/// Default per-user limit: 100 calls per ~600 ledgers (~1 hour at 6 s/ledger).
+pub const DEFAULT_MAX_CALLS: u32 = 100;
+pub const DEFAULT_WINDOW_LEDGERS: u32 = 600;
+
+pub struct RateLimiter;
+
+impl RateLimiter {
+    /// Check and record a call from `caller` to `endpoint`.
+    ///
+    /// Returns `Ok(())` if within limits, or `Err(BridgeError::RetryLimitExceeded)`
+    /// when the per-user limit is exceeded.
+    ///
+    /// Uses the default limit unless an endpoint-specific config is stored.
+    pub fn check_rate_limit(
+        env: &Env,
+        caller: &Address,
+        endpoint: &Symbol,
+    ) -> Result<(), BridgeError> {
+        let config = Self::get_config(env, endpoint);
+        let key = Self::state_key(caller, endpoint);
+        let current_seq = env.ledger().sequence();
+
+        let mut state: RateLimitState = env
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or(RateLimitState {
+                window_start: current_seq,
+                call_count: 0,
+            });
+
+        // Reset window if it has expired
+        if current_seq.saturating_sub(state.window_start) >= config.window_ledgers {
+            state.window_start = current_seq;
+            state.call_count = 0;
+        }
+
+        if state.call_count >= config.max_calls {
+            return Err(BridgeError::RetryLimitExceeded);
+        }
+
+        state.call_count += 1;
+        env.storage().instance().set(&key, &state);
+        Ok(())
+    }
+
+    /// Set a custom rate-limit config for a specific endpoint (admin action).
+    pub fn set_endpoint_config(env: &Env, endpoint: &Symbol, config: EndpointConfig) {
+        let configs_key = StorageKey::RateLimitState;
+        let mut configs: Map<Symbol, EndpointConfig> = env
+            .storage()
+            .instance()
+            .get(&configs_key)
+            .unwrap_or_else(|| Map::new(env));
+        configs.set(endpoint.clone(), config);
+        env.storage().instance().set(&configs_key, &configs);
+    }
+
+    /// Get the config for an endpoint, falling back to defaults.
+    fn get_config(env: &Env, endpoint: &Symbol) -> EndpointConfig {
+        let configs_key = StorageKey::RateLimitState;
+        let configs: Map<Symbol, EndpointConfig> = env
+            .storage()
+            .instance()
+            .get(&configs_key)
+            .unwrap_or_else(|| Map::new(env));
+        configs.get(endpoint.clone()).unwrap_or(EndpointConfig {
+            max_calls: DEFAULT_MAX_CALLS,
+            window_ledgers: DEFAULT_WINDOW_LEDGERS,
+        })
+    }
+
+    /// Composite storage key for a (caller, endpoint) pair.
+    /// Uses a tuple so each pair gets a unique slot — no collisions.
+    fn state_key(caller: &Address, endpoint: &Symbol) -> (Address, Symbol) {
+        (caller.clone(), endpoint.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TeachLinkBridge;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    fn set_seq(env: &Env, seq: u32) {
+        env.ledger().with_mut(|li| li.sequence_number = seq);
+    }
+
+    #[test]
+    fn allows_calls_within_limit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+        let caller = Address::generate(&env);
+        let ep = symbol_short!("bridge");
+
+        env.as_contract(&contract_id, || {
+            // Set a tight limit for testing
+            RateLimiter::set_endpoint_config(
+                &env,
+                &ep,
+                EndpointConfig {
+                    max_calls: 3,
+                    window_ledgers: 100,
+                },
+            );
+            set_seq(&env, 1);
+            assert!(RateLimiter::check_rate_limit(&env, &caller, &ep).is_ok());
+            assert!(RateLimiter::check_rate_limit(&env, &caller, &ep).is_ok());
+            assert!(RateLimiter::check_rate_limit(&env, &caller, &ep).is_ok());
+            // 4th call should be rejected
+            assert_eq!(
+                RateLimiter::check_rate_limit(&env, &caller, &ep),
+                Err(BridgeError::RetryLimitExceeded)
+            );
+        });
+    }
+
+    #[test]
+    fn resets_after_window_expires() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+        let caller = Address::generate(&env);
+        let ep = symbol_short!("bridge");
+
+        env.as_contract(&contract_id, || {
+            RateLimiter::set_endpoint_config(
+                &env,
+                &ep,
+                EndpointConfig {
+                    max_calls: 1,
+                    window_ledgers: 10,
+                },
+            );
+            set_seq(&env, 1);
+            assert!(RateLimiter::check_rate_limit(&env, &caller, &ep).is_ok());
+            // Exhausted
+            assert!(RateLimiter::check_rate_limit(&env, &caller, &ep).is_err());
+            // Advance past window
+            set_seq(&env, 12);
+            // Should reset and allow again
+            assert!(RateLimiter::check_rate_limit(&env, &caller, &ep).is_ok());
+        });
+    }
+
+    #[test]
+    fn different_users_have_independent_limits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TeachLinkBridge, ());
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let ep = symbol_short!("bridge");
+
+        env.as_contract(&contract_id, || {
+            RateLimiter::set_endpoint_config(
+                &env,
+                &ep,
+                EndpointConfig {
+                    max_calls: 1,
+                    window_ledgers: 100,
+                },
+            );
+            set_seq(&env, 1);
+            assert!(RateLimiter::check_rate_limit(&env, &alice, &ep).is_ok());
+            // Alice exhausted, Bob still fine
+            assert!(RateLimiter::check_rate_limit(&env, &alice, &ep).is_err());
+            assert!(RateLimiter::check_rate_limit(&env, &bob, &ep).is_ok());
+        });
+    }
+}

--- a/contracts/teachlink/src/storage.rs
+++ b/contracts/teachlink/src/storage.rs
@@ -1,5 +1,62 @@
+use soroban_sdk::contracttype;
 use soroban_sdk::symbol_short;
 use soroban_sdk::Symbol;
+
+/// Namespaced storage key enum for TeachLink contract.
+///
+/// Using a `#[contracttype]` enum as a storage key ensures each variant is
+/// serialized with a unique discriminant, preventing key collisions in
+/// multi-contract scenarios where plain `Symbol` strings could overlap.
+///
+/// # Collision Detection
+/// All new storage access should use `StorageKey` variants. The legacy
+/// `Symbol` constants below are kept for backward compatibility but should
+/// not be used for new keys.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageKey {
+    // Bridge
+    Token,
+    Validators,
+    MinValidators,
+    Nonce,
+    BridgeTxs,
+    SupportedChains,
+    Admin,
+    FeeRecipient,
+    BridgeFee,
+    AccessControl,
+    BridgeRetryCounts,
+    BridgeLastRetry,
+    BridgeFailures,
+    InterfaceVersion,
+    MinCompatInterfaceVersion,
+    // BFT Consensus
+    ValidatorInfo,
+    BridgeProposals,
+    ProposalCounter,
+    ConsensusState,
+    ValidatorStakes,
+    ProposalExpiresSeq,
+    ValidatorActivitySeq,
+    // Slashing
+    SlashingRecords,
+    ValidatorRewards,
+    SlashingCounter,
+    RewardPool,
+    // Validator rotation tracking
+    ValidatorRotationEpoch,
+    ValidatorRotationSet,
+    // Rate limiting
+    RateLimitState,
+}
+
+/// Returns true if the given symbol string matches any known legacy key,
+/// providing a compile-time collision detection reference.
+/// Call this in tests to assert no two legacy keys share the same string.
+pub fn has_legacy_key_collision(a: &Symbol, b: &Symbol) -> bool {
+    a == b
+}
 
 // Storage keys for the bridge contract
 pub const TOKEN: Symbol = symbol_short!("token");
@@ -157,3 +214,48 @@ pub const BRIDGE_GUARD: Symbol = symbol_short!("br_guard");
 pub const REWARDS_GUARD: Symbol = symbol_short!("rw_guard");
 pub const SWAP_GUARD: Symbol = symbol_short!("sw_guard");
 pub const INSURANCE_GUARD: Symbol = symbol_short!("ins_guard");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that no two legacy Symbol constants share the same string value.
+    /// This is the collision detection required by issue #242.
+    #[test]
+    fn no_legacy_key_collisions() {
+        let keys: &[(&str, Symbol)] = &[
+            ("TOKEN", TOKEN),
+            ("VALIDATORS", VALIDATORS),
+            ("MIN_VALIDATORS", MIN_VALIDATORS),
+            ("NONCE", NONCE),
+            ("BRIDGE_TXS", BRIDGE_TXS),
+            ("SUPPORTED_CHAINS", SUPPORTED_CHAINS),
+            ("ADMIN", ADMIN),
+            ("FEE_RECIPIENT", FEE_RECIPIENT),
+            ("BRIDGE_FEE", BRIDGE_FEE),
+            ("ACCESS_CONTROL", ACCESS_CONTROL),
+            ("VALIDATOR_INFO", VALIDATOR_INFO),
+            ("BRIDGE_PROPOSALS", BRIDGE_PROPOSALS),
+            ("PROPOSAL_COUNTER", PROPOSAL_COUNTER),
+            ("CONSENSUS_STATE", CONSENSUS_STATE),
+            ("VALIDATOR_STAKES", VALIDATOR_STAKES),
+            ("SLASHING_RECORDS", SLASHING_RECORDS),
+            ("VALIDATOR_REWARDS", VALIDATOR_REWARDS),
+            ("SLASHING_COUNTER", SLASHING_COUNTER),
+            ("PROPOSAL_EXPIRES_SEQ", PROPOSAL_EXPIRES_SEQ),
+            ("VALIDATOR_ACTIVITY_SEQ", VALIDATOR_ACTIVITY_SEQ),
+            ("REWARD_POOL", REWARD_POOL),
+        ];
+
+        for i in 0..keys.len() {
+            for j in (i + 1)..keys.len() {
+                assert!(
+                    !has_legacy_key_collision(&keys[i].1, &keys[j].1),
+                    "Storage key collision detected: '{}' == '{}'",
+                    keys[i].0,
+                    keys[j].0
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #242
Closes #236
Closes #266

## Summary

### #242 — Storage key collision
- Added `StorageKey` enum with `#[contracttype]` derive to `storage.rs`
- Each variant gets a unique discriminant when serialized, preventing collisions in multi-contract scenarios
- Legacy `Symbol` constants kept for backward compat
- Added `has_legacy_key_collision` helper + collision detection test

### #236 — Validator manipulation in BFT consensus
- `rotate_validators()`: deactivates validators below `MIN_ACTIVE_REPUTATION` (40) or with insufficient stake
- `maybe_rotate()`: auto-triggers rotation at epoch boundaries (`ROTATION_EPOCH_ROUNDS = 100`)
- `boost_reputation()`: called on every successful vote for enhanced reputation tracking
- Exposed `rotate_validators` and `maybe_rotate_validators` as contract entry points
- Tests: `rotate_validators_removes_low_reputation`, `voting_boosts_reputation`

### #266 — Rate limiting for API endpoints
- New `rate_limiting.rs` module with `RateLimiter::check_rate_limit(env, caller, endpoint)`
- Per-user, per-endpoint limits using ledger sequence windows
- `EndpointConfig`: configurable `max_calls` + `window_ledgers` per endpoint
- Returns `BridgeError::RetryLimitExceeded` for graceful degradation
- Uses `StorageKey::RateLimitState` (namespaced, no collision)
- Tests: within-limit, window-reset, independent per-user limits