### PR TITLE
feat: add automated regression testing pipeline

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci]
+junit = { path = "junit.xml" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,2 @@
 [profile.ci]
-junit = { path = "junit.xml" }
+junit = { path = "junit.xml", report-name = "teachlink" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,55 @@ jobs:
 
       - name: Run integration tests
         run: cargo test --workspace --test cross_chain_integration
+
+  regression:
+    runs-on: ubuntu-latest
+    needs: rust
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Run regression tests (JUnit XML)
+        run: |
+          cargo nextest run --workspace --lib \
+            --profile ci \
+            2>&1 | tee test-output.txt
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: target/nextest/ci/junit.xml
+
+  performance:
+    runs-on: ubuntu-latest
+    needs: rust
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run performance baseline check
+        run: bash scripts/perf-baseline.sh
+
+      - name: Upload performance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-report
+          path: perf-report.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run integration tests
         run: cargo test --workspace --test cross_chain_integration
 
-  regression:
+  performance:
     runs-on: ubuntu-latest
     needs: rust
     steps:
@@ -43,6 +43,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -52,37 +54,29 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Run regression tests (JUnit XML)
+      - name: Run tests with timing
         run: |
-          cargo nextest run --workspace --lib \
-            --profile ci \
-            2>&1 | tee test-output.txt
+          START=$(date +%s)
+          cargo nextest run --workspace --lib --profile ci 2>&1 | tee test-output.txt
+          END=$(date +%s)
+          echo "unit_test_duration=$((END - START))" >> "$GITHUB_ENV"
+
+      - name: Build WASM (release)
+        run: cargo build --target wasm32v1-none --release -p teachlink-contract
+
+      - name: Capture performance baseline
+        run: bash scripts/perf-baseline.sh
 
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: ci-test-results
           path: target/nextest/ci/junit.xml
 
-  performance:
-    runs-on: ubuntu-latest
-    needs: rust
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-
-      - name: Run performance baseline check
-        run: bash scripts/perf-baseline.sh
-
-      - name: Upload performance report
+      - name: Upload performance baseline
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: performance-report
-          path: perf-report.json
+          name: ci-performance-baseline
+          path: baseline_current.json

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,83 @@
+name: Regression
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # ── Tests ────────────────────────────────────────────────────────────
+      - name: Run unit tests
+        run: |
+          START=$(date +%s)
+          cargo test --workspace --lib 2>&1 | tee ci_test_output.txt
+          END=$(date +%s)
+          echo "unit_test_duration=$((END - START))" >> "$GITHUB_ENV"
+
+      - name: Run integration tests
+        run: |
+          START=$(date +%s)
+          cargo test --workspace --tests 2>&1 | tee -a ci_test_output.txt
+          END=$(date +%s)
+          echo "integration_test_duration=$((END - START))" >> "$GITHUB_ENV"
+
+      # ── Performance baseline ─────────────────────────────────────────────
+      - name: Build WASM (release)
+        run: cargo build --target wasm32v1-none --release -p teachlink-contract
+
+      - name: Capture performance baseline
+        run: bash scripts/perf-baseline.sh
+
+      # ── Regression check ─────────────────────────────────────────────────
+      - name: Download previous baseline
+        id: dl_baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: baseline_previous.json
+          key: perf-baseline-${{ github.base_ref || 'main' }}
+          restore-keys: perf-baseline-
+
+      - name: Check for regressions
+        run: bash scripts/check-regression.sh
+
+      # ── Save new baseline (main branch only) ─────────────────────────────
+      - name: Save baseline to cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: baseline_current.json
+          key: perf-baseline-main
+
+      # ── Report ───────────────────────────────────────────────────────────
+      - name: Generate report
+        if: always()
+        run: bash scripts/generate-report.sh
+
+      - name: Upload regression report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-report-${{ github.run_number }}
+          path: regression_report.md
+          retention-days: 30
+
+      - name: Upload test output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-output-${{ github.run_number }}
+          path: ci_test_output.txt
+          retention-days: 14

--- a/scripts/check-regression.sh
+++ b/scripts/check-regression.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Compare baseline_current.json against baseline_previous.json.
+# Fails if WASM size or test duration regressed beyond thresholds.
+set -euo pipefail
+
+CURRENT="baseline_current.json"
+PREVIOUS="baseline_previous.json"
+
+# Thresholds
+WASM_LIMIT_BYTES=307200          # 300 KB hard limit
+WASM_REGRESSION_PCT=10           # fail if size grew >10% vs previous
+DURATION_REGRESSION_PCT=50       # fail if test time grew >50% vs previous
+
+if [ ! -f "$CURRENT" ]; then
+  echo "ERROR: $CURRENT not found. Run perf-baseline.sh first." >&2
+  exit 1
+fi
+
+read_field() { python3 -c "import json,sys; d=json.load(open('$1')); print(d.get('$2',0))"; }
+
+cur_wasm=$(read_field "$CURRENT" wasm_size_bytes)
+cur_unit=$(read_field "$CURRENT" unit_test_duration_s)
+cur_intg=$(read_field "$CURRENT" integration_test_duration_s)
+
+FAILED=0
+
+echo "=== Regression Check ==="
+echo "WASM size:            ${cur_wasm} bytes"
+echo "Unit test duration:   ${cur_unit}s"
+echo "Integration duration: ${cur_intg}s"
+
+# Hard WASM size limit
+if [ "$cur_wasm" -gt "$WASM_LIMIT_BYTES" ]; then
+  echo "FAIL: WASM size ${cur_wasm} bytes exceeds hard limit ${WASM_LIMIT_BYTES} bytes"
+  FAILED=1
+fi
+
+if [ -f "$PREVIOUS" ]; then
+  prev_wasm=$(read_field "$PREVIOUS" wasm_size_bytes)
+  prev_unit=$(read_field "$PREVIOUS" unit_test_duration_s)
+  prev_intg=$(read_field "$PREVIOUS" integration_test_duration_s)
+
+  echo ""
+  echo "--- vs previous baseline ---"
+  echo "Previous WASM:        ${prev_wasm} bytes"
+  echo "Previous unit:        ${prev_unit}s"
+  echo "Previous integration: ${prev_intg}s"
+
+  check_regression() {
+    local label=$1 cur=$2 prev=$3 pct=$4
+    if [ "$prev" -gt 0 ]; then
+      increase=$(python3 -c "print(int(($cur - $prev) * 100 / $prev))")
+      if [ "$increase" -gt "$pct" ]; then
+        echo "FAIL: $label increased by ${increase}% (threshold ${pct}%): ${prev} -> ${cur}"
+        FAILED=1
+      else
+        echo "OK:   $label change: ${increase}% (${prev} -> ${cur})"
+      fi
+    fi
+  }
+
+  check_regression "WASM size"            "$cur_wasm" "$prev_wasm" "$WASM_REGRESSION_PCT"
+  check_regression "Unit test duration"   "$cur_unit" "$prev_unit" "$DURATION_REGRESSION_PCT"
+  check_regression "Integration duration" "$cur_intg" "$prev_intg" "$DURATION_REGRESSION_PCT"
+else
+  echo "(No previous baseline found — skipping comparison)"
+fi
+
+echo ""
+if [ "$FAILED" -eq 1 ]; then
+  echo "RESULT: REGRESSION DETECTED"
+  exit 1
+else
+  echo "RESULT: PASSED"
+fi

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Generate regression_report.md from available artifacts.
+set -euo pipefail
+
+CURRENT="baseline_current.json"
+PREVIOUS="baseline_previous.json"
+REPORT="regression_report.md"
+TEST_OUTPUT="ci_test_output.txt"
+
+read_field() {
+  if [ -f "$1" ]; then
+    python3 -c "import json,sys; d=json.load(open('$1')); print(d.get('$2','N/A'))"
+  else
+    echo "N/A"
+  fi
+}
+
+commit=$(read_field "$CURRENT" commit)
+captured=$(read_field "$CURRENT" captured_at)
+wasm_cur=$(read_field "$CURRENT" wasm_size_bytes)
+unit_cur=$(read_field "$CURRENT" unit_test_duration_s)
+intg_cur=$(read_field "$CURRENT" integration_test_duration_s)
+
+wasm_prev=$(read_field "$PREVIOUS" wasm_size_bytes)
+unit_prev=$(read_field "$PREVIOUS" unit_test_duration_s)
+intg_prev=$(read_field "$PREVIOUS" integration_test_duration_s)
+
+delta() {
+  local cur=$1 prev=$2
+  if [ "$prev" = "N/A" ] || [ "$prev" = "0" ]; then echo "—"; return; fi
+  python3 -c "
+cur, prev = $cur, $prev
+d = cur - prev
+sign = '+' if d >= 0 else ''
+pct = d * 100 / prev if prev else 0
+print(f'{sign}{d} ({sign}{pct:.1f}%)')
+"
+}
+
+# Count test results
+passed=0; failed=0
+if [ -f "$TEST_OUTPUT" ]; then
+  passed=$(grep -c "^test .* ok$" "$TEST_OUTPUT" 2>/dev/null || true)
+  failed=$(grep -c "^test .* FAILED$" "$TEST_OUTPUT" 2>/dev/null || true)
+fi
+
+cat > "$REPORT" <<EOF
+# Regression Report
+
+**Commit:** \`${commit}\`
+**Generated:** ${captured}
+
+## Test Results
+
+| Suite | Status |
+|-------|--------|
+| Unit tests | $([ "$failed" -eq 0 ] && echo "✅ Passed" || echo "❌ Failed") |
+| Integration tests | $([ "$failed" -eq 0 ] && echo "✅ Passed" || echo "❌ Failed") |
+
+Tests passed: **${passed}** | Failed: **${failed}**
+
+## Performance
+
+| Metric | Current | Previous | Delta |
+|--------|---------|----------|-------|
+| WASM size (bytes) | ${wasm_cur} | ${wasm_prev} | $(delta "$wasm_cur" "$wasm_prev") |
+| Unit test time (s) | ${unit_cur} | ${unit_prev} | $(delta "$unit_cur" "$unit_prev") |
+| Integration time (s) | ${intg_cur} | ${intg_prev} | $(delta "$intg_cur" "$intg_prev") |
+
+## Thresholds
+
+| Check | Threshold |
+|-------|-----------|
+| WASM hard limit | 300 KB (307200 bytes) |
+| WASM size regression | +10% vs baseline |
+| Test duration regression | +50% vs baseline |
+EOF
+
+echo "Report written to $REPORT"
+cat "$REPORT"

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Capture WASM size and test timing into baseline_current.json
+set -euo pipefail
+
+WASM="target/wasm32v1-none/release/teachlink_contract.wasm"
+
+if [ ! -f "$WASM" ]; then
+  echo "ERROR: WASM not found at $WASM" >&2
+  exit 1
+fi
+
+wasm_bytes=$(stat -c%s "$WASM")
+
+unit_secs="${unit_test_duration:-0}"
+integration_secs="${integration_test_duration:-0}"
+
+cat > baseline_current.json <<EOF
+{
+  "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "commit": "${GITHUB_SHA:-local}",
+  "wasm_size_bytes": ${wasm_bytes},
+  "unit_test_duration_s": ${unit_secs},
+  "integration_test_duration_s": ${integration_secs}
+}
+EOF
+
+echo "Baseline captured:"
+cat baseline_current.json


### PR DESCRIPTION
Summary
  
  Introduces a GitHub Actions regression pipeline that runs on every push and pull request to
  catch test failures and performance regressions before they reach main.
  
  Changes
  
  - .github/workflows/regression.yml — new CI workflow: runs unit + integration tests, builds
  WASM, checks regressions, uploads reports
  - scripts/perf-baseline.sh — captures WASM size and test durations into a JSON baseline
  - scripts/check-regression.sh — compares current run against the previous baseline and fails on
  violations
  - scripts/generate-report.sh — produces a markdown summary uploaded as a CI artifact
  
  Regression Thresholds
  
  ┌─────────────────┬───────────┐
  │ Check           │ Threshold │
  ├──────────────────┼──────────────────┤
  │ WASM hard limit  │ 300 KB           │
  ├──────────────────────┼──────────────────┤
  │ WASM size growth     │ +10% vs baseline │
  ├──────────────────────┼──────────────────┤
  │ Test duration growth │ +50% vs baseline │
  └──────────────────────┴──────────────────┘
  
  What was tested
  
  - Workflow syntax validated locally
  - Scripts are executable and handle missing baseline gracefully (first run skips comparison)
  - Baseline is cached per branch; PRs compare against the main baseline

closes #265 