### PR TITLE
docs: add comprehensive inline documentation to core modules

### DIFF
--- a/contracts/documentation/src/lib.rs
+++ b/contracts/documentation/src/lib.rs
@@ -2,12 +2,48 @@
 //!
 //! A smart contract for managing documentation, knowledge base articles,
 //! FAQs, tutorials, and community-contributed content.
+//!
+//! # Storage Model
+//!
+//! Articles and FAQs are stored in **instance storage** keyed directly by
+//! their string `id`.  This means:
+//! - IDs must be unique across both articles and FAQs (they share the same
+//!   storage namespace).
+//! - Calling `create_article` with an existing ID overwrites the record but
+//!   does **not** increment the article count (idempotent upsert).
+//!
+//! Counters (`ArticleCount`, `FaqCount`) are stored under `DocKey` enum
+//! variants to avoid collisions with content IDs.
+//!
+//! # Overflow Protection
+//!
+//! All counter increments and version bumps use `checked_add` with an
+//! explicit `expect` message.  On Soroban, a panic aborts the transaction
+//! and rolls back all state changes, so overflow is safe to panic on.
+//!
+//! # Versioning
+//!
+//! Each `update_article` call increments `article.version` starting from 1.
+//! The `created_at` timestamp is preserved across updates; only `updated_at`
+//! changes.  This allows clients to detect staleness without comparing content.
+//!
+//! # TODO
+//! - Implement `search_articles` with an on-chain inverted index or off-chain
+//!   indexer integration (current implementation returns an empty vector).
+//! - Add author authorization check to `update_article` so only the original
+//!   author or an admin can modify content.
+//! - Separate article and FAQ storage namespaces to prevent ID collisions.
 
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec};
 
-/// Documentation category types
+/// Documentation category types.
+///
+/// Used to classify articles for filtering and navigation.
+/// `Faq` overlaps with the dedicated `FaqEntry` type — prefer `FaqEntry`
+/// for structured Q&A content and `DocCategory::Faq` only for article-style
+/// FAQ pages.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DocCategory {
@@ -19,7 +55,16 @@ pub enum DocCategory {
     Troubleshooting,
 }
 
-/// Content visibility levels
+/// Content visibility levels.
+///
+/// Controls who can read an article:
+/// - `Public`    – visible to all users, including unauthenticated.
+/// - `Community` – visible to registered TeachLink users only.
+/// - `Private`   – visible to the author and admins only.
+///
+/// # TODO
+/// - Enforce visibility at the read path (`get_article`) once an
+///   authentication context is available in the contract.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Visibility {
@@ -28,7 +73,15 @@ pub enum Visibility {
     Private,
 }
 
-/// A documentation article
+/// A documentation article.
+///
+/// Articles are the primary content unit.  The `version` field starts at 1
+/// and is incremented on every `update_article` call.  `created_at` is
+/// immutable after creation; `updated_at` reflects the last modification.
+///
+/// `view_count` and `helpful_count` are analytics counters incremented by
+/// `record_view` and `mark_helpful` respectively.  Both use `checked_add`
+/// to panic on overflow rather than silently wrapping.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Article {
@@ -36,25 +89,41 @@ pub struct Article {
     pub title: String,
     pub content: String,
     pub category: DocCategory,
+    /// BCP-47 language tag (e.g. "en", "es", "zh-CN").
     pub language: String,
+    /// Monotonically increasing version counter, starting at 1.
     pub version: u32,
     pub author: Address,
     pub visibility: Visibility,
     pub tags: Vec<String>,
+    /// Unix timestamp (seconds) when the article was first created.
     pub created_at: u64,
+    /// Unix timestamp (seconds) of the most recent update.
     pub updated_at: u64,
+    /// Total number of times this article has been viewed.
     pub view_count: u64,
+    /// Total number of users who marked this article as helpful.
     pub helpful_count: u64,
 }
 
-/// A FAQ entry
+/// A FAQ entry.
+///
+/// Structured Q&A content distinct from general articles.  FAQs share the
+/// same instance storage namespace as articles, so their IDs must not
+/// collide with article IDs.
+///
+/// # TODO
+/// - Add a `related_article_ids: Vec<String>` field to link FAQs to
+///   relevant documentation articles.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FaqEntry {
     pub id: String,
     pub question: String,
     pub answer: String,
+    /// Free-form category string (e.g. "billing", "technical").
     pub category: String,
+    /// BCP-47 language tag.
     pub language: String,
     pub author: Address,
     pub created_at: u64,
@@ -62,11 +131,17 @@ pub struct FaqEntry {
     pub helpful_count: u64,
 }
 
-/// Documentation contract storage keys
+/// Documentation contract storage keys.
+///
+/// Enum variants are used as storage keys to avoid string-based key
+/// collisions with content IDs stored directly by their string value.
 #[contracttype]
 enum DocKey {
+    /// Total number of unique article IDs ever created.
     ArticleCount,
+    /// Total number of unique FAQ IDs ever created.
     FaqCount,
+    /// Global documentation schema version.
     Version,
 }
 
@@ -76,7 +151,21 @@ pub struct DocumentationContract;
 
 #[contractimpl]
 impl DocumentationContract {
-    /// Create a new documentation article
+    /// Create a new documentation article (upsert by ID).
+    ///
+    /// If an article with the same `id` already exists, it is overwritten
+    /// but the `ArticleCount` is **not** incremented (idempotent upsert).
+    /// The `created_at` timestamp reflects the time of this call, not the
+    /// original creation time — callers should use `update_article` for
+    /// in-place edits to preserve `created_at`.
+    ///
+    /// # Overflow Protection
+    /// `ArticleCount` uses `checked_add` and panics on overflow, aborting
+    /// the transaction before any state is committed.
+    ///
+    /// # TODO
+    /// - Require `author.require_auth()` to prevent anyone from creating
+    ///   articles on behalf of another address.
     pub fn create_article(
         env: Env,
         id: String,
@@ -127,7 +216,20 @@ impl DocumentationContract {
         env.storage().instance().get(&id).unwrap()
     }
 
-    /// Update an existing article
+    /// Update an existing article's content, title, and tags.
+    ///
+    /// Increments `version` and updates `updated_at`.  `created_at` and
+    /// `author` are preserved.  Panics if the article does not exist
+    /// (unwrap on missing storage entry).
+    ///
+    /// # Version Overflow
+    /// `version` uses `checked_add` and panics at `u32::MAX`.  In practice
+    /// this requires ~4 billion updates to a single article, which is
+    /// unreachable in normal operation.
+    ///
+    /// # TODO
+    /// - Add `caller: Address` parameter and verify `caller == article.author`
+    ///   or caller has admin role before allowing the update.
     pub fn update_article(
         env: Env,
         id: String,
@@ -151,7 +253,11 @@ impl DocumentationContract {
         article
     }
 
-    /// Record a view for analytics
+    /// Record a view for analytics.
+    ///
+    /// Increments `view_count` using `checked_add` to panic on overflow
+    /// rather than silently wrapping.  No authentication required — views
+    /// are public read events.
     pub fn record_view(env: Env, article_id: String) {
         let mut article: Article = env.storage().instance().get(&article_id).unwrap();
         article.view_count = article
@@ -162,7 +268,14 @@ impl DocumentationContract {
         env.storage().instance().set(&article_id, &article);
     }
 
-    /// Record that a user found an article helpful
+    /// Record that a user found an article helpful.
+    ///
+    /// Increments `helpful_count` using `checked_add`.  No deduplication —
+    /// the same user can mark an article helpful multiple times.
+    ///
+    /// # TODO
+    /// - Track which addresses have already voted to prevent duplicate
+    ///   helpful counts from inflating article quality signals.
     pub fn mark_helpful(env: Env, article_id: String) {
         let mut article: Article = env.storage().instance().get(&article_id).unwrap();
         article.helpful_count = article
@@ -173,7 +286,13 @@ impl DocumentationContract {
         env.storage().instance().set(&article_id, &article);
     }
 
-    /// Create a new FAQ entry
+    /// Create a new FAQ entry (upsert by ID).
+    ///
+    /// Same upsert semantics as `create_article`: existing entries are
+    /// overwritten without incrementing `FaqCount`.
+    ///
+    /// # TODO
+    /// - Require `author.require_auth()` to prevent impersonation.
     pub fn create_faq(
         env: Env,
         id: String,
@@ -218,7 +337,17 @@ impl DocumentationContract {
         env.storage().instance().get(&id).unwrap()
     }
 
-    /// Search articles by keyword (simplified implementation)
+    /// Search articles by keyword (stub implementation).
+    ///
+    /// # Current Behaviour
+    /// Always returns an empty vector.  Full-text search requires either:
+    /// 1. An off-chain indexer that listens to article creation events and
+    ///    exposes a query API.
+    /// 2. An on-chain inverted index (expensive in terms of storage and gas).
+    ///
+    /// # TODO
+    /// - Integrate with an off-chain indexer via oracle or implement a
+    ///   tag-based search using a `Map<String, Vec<String>>` tag index.
     pub fn search_articles(env: Env, _query: String) -> Vec<Article> {
         // In a full implementation, this would search through articles
         // For now, return empty vector as placeholder

--- a/contracts/teachlink/src/atomic_swap.rs
+++ b/contracts/teachlink/src/atomic_swap.rs
@@ -2,6 +2,43 @@
 //!
 //! This module implements atomic swap functionality for cross-chain token exchanges
 //! using hash time-locked contracts (HTLC).
+//!
+//! # HTLC Protocol
+//!
+//! An atomic swap between two parties (initiator A and counterparty B) proceeds
+//! as follows:
+//!
+//! ```text
+//! 1. A chooses a secret `preimage` and computes `hashlock = SHA256(preimage)`.
+//! 2. A calls `initiate_swap`, locking their tokens and publishing `hashlock`.
+//! 3. B calls `accept_swap` with the correct `preimage` to claim A's tokens
+//!    and simultaneously release their own tokens to A.
+//! 4. If B does not act before `timelock` expires, A calls `refund_swap`
+//!    to recover their locked tokens.
+//! ```
+//!
+//! Atomicity is guaranteed because B can only claim A's tokens by revealing
+//! `preimage`, which A can then use to claim B's tokens on the other chain.
+//!
+//! # Timelock Dual-Signal
+//!
+//! Like proposals, swaps store both a wall-clock `timelock` timestamp and a
+//! `SWAP_TIMELOCK_SEQ` ledger-sequence deadline.  Expiry is triggered if
+//! *either* signal is exceeded, guarding against frozen-clock test networks.
+//!
+//! # Hashlock Verification
+//!
+//! The 32-byte `hashlock` must equal `SHA256(preimage)`.  The contract
+//! enforces `hashlock.len() == HASH_LENGTH (32)` at initiation time.
+//!
+//! # Reentrancy Protection
+//!
+//! Both `initiate_swap` and `accept_swap` are wrapped in `reentrancy::with_guard`
+//! using `SWAP_GUARD` to prevent recursive calls during token transfers.
+//!
+//! # Spec Reference
+//! See `contracts/documentation/COLLABORATION.md` §Atomic Swaps for the
+//! cross-chain exchange specification.
 
 use crate::errors::BridgeError;
 use crate::events::{SwapCompletedEvent, SwapInitiatedEvent, SwapRefundedEvent};
@@ -23,6 +60,18 @@ pub const HASH_LENGTH: u32 = 32;
 pub struct AtomicSwapManager;
 
 impl AtomicSwapManager {
+    /// Checks whether a swap's timelock has expired using a dual-signal approach.
+    ///
+    /// # Algorithm
+    ///
+    /// 1. **Primary – wall-clock timestamp**: expired if `now > timelock_ts`.
+    /// 2. **Fallback – ledger sequence**: if the timestamp check passes, also
+    ///    check the stored `SWAP_TIMELOCK_SEQ` entry.  Expired if
+    ///    `current_sequence > seq_deadline`.
+    ///
+    /// Returns `true` if *either* signal indicates expiry.  This dual-signal
+    /// approach prevents swaps from being stuck open on networks where
+    /// `ledger().timestamp()` is not advancing (e.g., local test environments).
     fn timelock_expired(env: &Env, swap_id: u64, timelock_ts: u64) -> bool {
         if env.ledger().timestamp() > timelock_ts {
             return true;

--- a/contracts/teachlink/src/audit.rs
+++ b/contracts/teachlink/src/audit.rs
@@ -2,6 +2,32 @@
 //!
 //! This module implements comprehensive audit logging and compliance reporting
 //! for regulatory requirements and operational transparency.
+//!
+//! # Circular Buffer Design
+//!
+//! Audit records are stored in a fixed-size circular buffer capped at
+//! `MAX_AUDIT_RECORDS` (100 000 entries).  When the counter reaches the cap,
+//! it resets to 0 and new records overwrite the oldest ones.  This bounds
+//! on-chain storage growth while preserving recent history.
+//!
+//! ```text
+//! record_id = (counter % MAX_AUDIT_RECORDS) + 1
+//! ```
+//!
+//! Off-chain indexers should consume events in real time to avoid missing
+//! records that have been overwritten.
+//!
+//! # Compliance Reports
+//!
+//! Reports aggregate audit records over a configurable time window
+//! (`COMPLIANCE_PERIOD` = 7 days by default).  They are generated on-demand
+//! and stored by period start timestamp.
+//!
+//! # TODO
+//! - Emit a warning event when the circular buffer wraps around so off-chain
+//!   monitors can detect potential data loss.
+//! - Add a Merkle root over the audit records in each compliance report so
+//!   the integrity of the audit trail can be verified without reading all records.
 
 use crate::errors::BridgeError;
 use crate::events::AuditRecordCreatedEvent;
@@ -19,7 +45,25 @@ pub const COMPLIANCE_PERIOD: u64 = 604_800;
 pub struct AuditManager;
 
 impl AuditManager {
-    /// Create an audit record
+    /// Create an audit record.
+    ///
+    /// # Circular Buffer Algorithm
+    ///
+    /// The audit counter is incremented on each call.  When it reaches
+    /// `MAX_AUDIT_RECORDS`, it resets to 0 before incrementing, causing the
+    /// new record to overwrite the oldest entry in the map.  This keeps
+    /// storage bounded at `MAX_AUDIT_RECORDS` entries.
+    ///
+    /// ```text
+    /// if counter >= MAX_AUDIT_RECORDS { counter = 0 }
+    /// counter += 1
+    /// records[counter] = new_record
+    /// ```
+    ///
+    /// # Note
+    /// Record IDs are not globally unique after a wrap-around.  Off-chain
+    /// consumers should use the emitted `AuditRecordCreatedEvent` timestamp
+    /// as the primary ordering key.
     pub fn create_audit_record(
         env: &Env,
         operation_type: OperationType,

--- a/contracts/teachlink/src/bft_consensus.rs
+++ b/contracts/teachlink/src/bft_consensus.rs
@@ -2,6 +2,49 @@
 //!
 //! This module implements a BFT consensus mechanism for bridge validators,
 //! ensuring that the bridge can tolerate up to f faulty validators out of 3f+1 total validators.
+//!
+//! # BFT Threshold Algorithm
+//!
+//! The Byzantine threshold (minimum votes required to approve a proposal) is
+//! computed as:
+//!
+//! ```text
+//! byzantine_threshold = floor(2 * n / 3) + 1
+//! ```
+//!
+//! where `n` is the number of active validators.  This satisfies the classic
+//! BFT requirement: a quorum of ⌈2n/3⌉ guarantees safety even when up to
+//! ⌊n/3⌋ validators are Byzantine (malicious or offline).
+//!
+//! Example: with 10 validators, threshold = (2*10/3)+1 = 7.  An attacker
+//! controlling 3 validators cannot reach quorum alone.
+//!
+//! # Proposal Lifecycle
+//!
+//! ```text
+//! create_proposal → Pending
+//!     ↓ (votes accumulate)
+//! vote_count >= byzantine_threshold → execute_proposal → Approved
+//!     ↓ (timeout reached)
+//! expires_at exceeded → Expired
+//! ```
+//!
+//! # Expiry Dual-Signal
+//!
+//! Proposals store both a wall-clock `expires_at` timestamp and a
+//! `PROPOSAL_EXPIRES_SEQ` ledger-sequence deadline.  Expiry is triggered if
+//! *either* signal indicates the deadline has passed.  This guards against
+//! networks where `ledger().timestamp()` is frozen or unreliable.
+//!
+//! # Validator Rotation
+//!
+//! Every `ROTATION_EPOCH_ROUNDS` consensus rounds, validators with
+//! `reputation_score < MIN_ACTIVE_REPUTATION` are rotated out of the active
+//! set.  Active voters receive a reputation boost to reward participation.
+//!
+//! # Spec Reference
+//! See `contracts/documentation/COLLABORATION.md` §Consensus for the
+//! governance rationale behind the rotation policy.
 
 use crate::errors::BridgeError;
 use crate::events::{
@@ -178,7 +221,24 @@ impl BFTConsensus {
         Ok(())
     }
 
-    /// Create a new bridge proposal
+    /// Create a new bridge proposal.
+    ///
+    /// Proposals represent a cross-chain message that validators must reach
+    /// consensus on before the bridge releases funds on the destination chain.
+    ///
+    /// # Expiry Dual-Signal
+    ///
+    /// Two independent expiry signals are stored:
+    /// - `expires_at`: wall-clock timestamp (`now + PROPOSAL_TIMEOUT`).
+    /// - `PROPOSAL_EXPIRES_SEQ`: ledger sequence deadline, computed via
+    ///   `ledger_time::seconds_to_ledger_delta` as a fallback for networks
+    ///   where `timestamp()` is unreliable.
+    ///
+    /// A proposal is considered expired if *either* signal is exceeded.
+    ///
+    /// # TODO
+    /// - Add a proposer field so off-chain indexers can attribute proposals
+    ///   to specific relayers for analytics and accountability.
     pub fn create_proposal(env: &Env, message: CrossChainMessage) -> Result<u64, BridgeError> {
         // Get proposal counter
         let mut proposal_counter: u64 = env
@@ -254,7 +314,29 @@ impl BFTConsensus {
         Ok(proposal_counter)
     }
 
-    /// Vote on a bridge proposal
+    /// Vote on a bridge proposal.
+    ///
+    /// # Voting Algorithm
+    ///
+    /// 1. Verify the caller is an active validator (registered and not rotated out).
+    /// 2. Check proposal expiry using the dual-signal approach (timestamp + sequence).
+    /// 3. Reject duplicate votes (one vote per validator per proposal).
+    /// 4. Record the vote; increment `vote_count` only for approvals.
+    /// 5. Update the validator's `last_activity` timestamp and ledger sequence
+    ///    to prevent false inactivity slashing.
+    /// 6. Boost the validator's reputation score for participating.
+    /// 7. If `vote_count >= required_votes`, immediately execute the proposal
+    ///    (mark as Approved and emit `ProposalExecutedEvent`).
+    ///
+    /// # Note on Rejection Votes
+    ///
+    /// Rejection votes are recorded in `proposal.votes` but do not increment
+    /// `vote_count`.  A proposal can only be approved, not explicitly rejected —
+    /// it expires if it fails to accumulate enough approvals within the timeout.
+    ///
+    /// # TODO
+    /// - Implement explicit rejection: if `reject_count > n - byzantine_threshold`,
+    ///   mark the proposal as `Rejected` early to free storage.
     pub fn vote_on_proposal(
         env: &Env,
         validator: Address,
@@ -379,7 +461,27 @@ impl BFTConsensus {
         Ok(())
     }
 
-    /// Update the consensus state based on current validators
+    /// Update the consensus state based on current validators.
+    ///
+    /// # Algorithm
+    ///
+    /// Iterates all registered validators, summing stake and counting active
+    /// entries.  Then computes the Byzantine threshold:
+    ///
+    /// ```text
+    /// byzantine_threshold = floor(2 * active_validators / 3) + 1
+    /// ```
+    ///
+    /// This is the minimum number of approving votes required for a proposal
+    /// to reach consensus.  The formula satisfies BFT safety: with `n = 3f+1`
+    /// validators, `2f+1` votes are needed, tolerating `f` Byzantine nodes.
+    ///
+    /// Called after every validator registration or unregistration to keep the
+    /// threshold in sync with the current validator set size.
+    ///
+    /// # TODO
+    /// - Weight the threshold by stake rather than validator count to make
+    ///   Sybil attacks more expensive (stake-weighted BFT).
     fn update_consensus_state(env: &Env) -> Result<(), BridgeError> {
         let validators: Map<Address, bool> = env
             .storage()

--- a/contracts/teachlink/src/bridge.rs
+++ b/contracts/teachlink/src/bridge.rs
@@ -15,8 +15,23 @@ use crate::types::{BridgeTransaction, CrossChainMessage};
 use crate::validation::BridgeValidator;
 use soroban_sdk::{symbol_short, vec, Address, Bytes, Env, IntoVal, Map, Vec};
 
+/// Bridge transaction timeout (7 days).  After this period a pending
+/// transaction can be cancelled and the locked tokens refunded.
 const BRIDGE_TIMEOUT_SECONDS: u64 = 604_800;
+
+/// Maximum number of retry attempts before a bridge transaction is permanently
+/// marked as failed.  Prevents infinite retry loops consuming gas.
 const MAX_BRIDGE_RETRY_ATTEMPTS: u32 = 5;
+
+/// Base delay between retry attempts (5 minutes).  Combined with the attempt
+/// counter this implements an exponential back-off:
+///   delay = BASE * 2^(attempt - 1)
+/// so retries are spaced at 5 min, 10 min, 20 min, 40 min, 80 min.
+///
+/// # TODO
+/// - Expose `MAX_BRIDGE_RETRY_ATTEMPTS` and `BRIDGE_RETRY_DELAY_BASE_SECONDS`
+///   as admin-configurable parameters so they can be tuned without a contract
+///   upgrade.
 const BRIDGE_RETRY_DELAY_BASE_SECONDS: u64 = 300;
 
 pub struct Bridge;

--- a/contracts/teachlink/src/errors.rs
+++ b/contracts/teachlink/src/errors.rs
@@ -1,6 +1,27 @@
 use soroban_sdk::contracterror;
 
-/// Bridge module errors
+/// Bridge module errors.
+///
+/// Error codes are in the range 100–147.  Each code is stable across contract
+/// upgrades — never reuse or renumber a code, only append new ones.
+///
+/// # Code Ranges
+/// | Range   | Domain                          |
+/// |---------|---------------------------------|
+/// | 100–110 | Core bridge operations          |
+/// | 111–117 | BFT consensus                   |
+/// | 118–120 | Validator slashing              |
+/// | 121–123 | Multi-chain configuration       |
+/// | 124–126 | Liquidity pool                  |
+/// | 127–130 | Emergency / circuit breaker     |
+/// | 131–133 | Cross-chain message passing     |
+/// | 134–137 | Atomic swaps (HTLC)             |
+/// | 138–142 | General / retry                 |
+/// | 143–147 | Storage / versioning / reentrancy|
+///
+/// # TODO
+/// - Add `BridgeError::RateLimitExceeded` (148) for per-user rate limiting
+///   once the rate-limiting module is fully integrated.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BridgeError {

--- a/contracts/teachlink/src/liquidity.rs
+++ b/contracts/teachlink/src/liquidity.rs
@@ -2,6 +2,70 @@
 //!
 //! This module implements liquidity pool management and automated market making
 //! for optimizing bridge operations and dynamic fee pricing.
+//!
+//! # Dynamic Fee Algorithm
+//!
+//! The bridge fee is computed in three stages:
+//!
+//! ```text
+//! 1. base_fee_amount   = amount * base_fee_bps / 10_000
+//! 2. congestion_adj    = base_fee_amount * congestion_multiplier / 100
+//! 3. final_fee         = congestion_adj * (10_000 - volume_discount_bps) / 10_000
+//! ```
+//!
+//! The result is clamped to `[MIN_FEE_BPS, MAX_FEE_BPS]` of the transfer amount.
+//!
+//! ## Congestion Multiplier
+//!
+//! Derived from pool utilisation (`locked / total`):
+//!
+//! | Utilisation | Multiplier |
+//! |-------------|-----------|
+//! | < 50 %      | 1.0×      |
+//! | 50 – 70 %   | 1.5×      |
+//! | 70 – 90 %   | 2.0×      |
+//! | ≥ 90 %      | 3.0×      |
+//!
+//! ## Volume Discount
+//!
+//! Users with higher 24-hour trading volume receive a fee discount.  The
+//! discount is looked up from a configurable tier map (threshold → discount_bps).
+//! The highest matching tier wins.
+//!
+//! Default tiers:
+//! | 24h Volume  | Discount |
+//! |-------------|---------|
+//! | < $10k      |  0 %    |
+//! | $10k–$100k  |  5 %    |
+//! | $100k–$500k | 10 %    |
+//! | > $500k     | 20 %    |
+//!
+//! # LP Share Calculation
+//!
+//! LP share percentages are stored in basis points (10 000 = 100 %).
+//! When a provider adds liquidity, their share is recalculated against the
+//! *post-deposit* total to avoid inflating the percentage:
+//!
+//! ```text
+//! share_bps = (provider_amount * 10_000) / new_total_liquidity
+//! ```
+//!
+//! # LP Reward Calculation
+//!
+//! Rewards use scaled integer arithmetic to avoid precision loss:
+//!
+//! ```text
+//! reward = (position.amount * SCALE / total_liquidity) * position.amount / SCALE
+//!        ≈ position.amount² / total_liquidity
+//! ```
+//!
+//! where `SCALE = 1_000_000`.  This is equivalent to `amount * (amount / total)`
+//! but avoids the inner division truncating to zero for small positions.
+//!
+//! # TODO
+//! - Implement time-weighted LP rewards so long-term providers earn more than
+//!   flash liquidity providers.
+//! - Add slippage protection for large bridge transactions relative to pool size.
 
 use crate::errors::BridgeError;
 use crate::events::{FeeUpdatedEvent, LiquidityAddedEvent, LiquidityRemovedEvent};
@@ -256,7 +320,32 @@ impl LiquidityManager {
         Ok(())
     }
 
-    /// Calculate dynamic bridge fee
+    /// Calculate dynamic bridge fee.
+    ///
+    /// # Algorithm
+    ///
+    /// Three-stage computation (all arithmetic in basis points):
+    ///
+    /// ```text
+    /// base_fee_amount = amount * base_fee_bps / 10_000
+    /// congestion_adj  = base_fee_amount * congestion_multiplier / 100
+    /// final_fee       = congestion_adj * (10_000 - volume_discount_bps) / 10_000
+    /// ```
+    ///
+    /// The result is clamped to `[MIN_FEE_BPS, MAX_FEE_BPS]` of `amount` to
+    /// prevent fees from being zero (dust attacks) or excessively large.
+    ///
+    /// If no pool exists for `chain_id`, the congestion multiplier defaults to
+    /// 1× (100) so the fee degrades gracefully to the base rate.
+    ///
+    /// # Parameters
+    /// - `chain_id`       – Target chain; used to look up pool utilisation.
+    /// - `amount`         – Transfer amount in token base units.
+    /// - `user_volume_24h`– Caller's 24-hour trading volume for discount lookup.
+    ///
+    /// # TODO
+    /// - Cache the fee structure in a performance layer to avoid repeated
+    ///   storage reads on high-frequency bridging.
     pub fn calculate_bridge_fee(
         env: &Env,
         chain_id: u32,
@@ -351,7 +440,25 @@ impl LiquidityManager {
         Ok(())
     }
 
-    /// Calculate congestion multiplier based on pool utilization
+    /// Calculate congestion multiplier based on pool utilization.
+    ///
+    /// # Algorithm
+    ///
+    /// Computes utilisation as `locked_liquidity * 10_000 / total_liquidity`
+    /// (basis points), then maps it to a step-function multiplier:
+    ///
+    /// | Utilisation (bp) | Multiplier (%) | Effective fee multiplier |
+    /// |-----------------|---------------|--------------------------|
+    /// | < 5 000 (50 %)  | 100           | 1.0×                     |
+    /// | 5 000 – 7 000   | 150           | 1.5×                     |
+    /// | 7 000 – 9 000   | 200           | 2.0×                     |
+    /// | ≥ 9 000 (90 %)  | 300           | 3.0×                     |
+    ///
+    /// Returns 100 (1×) when the pool is empty to avoid division by zero.
+    ///
+    /// # TODO
+    /// - Replace the step function with a smooth curve (e.g., linear or
+    ///   exponential) to reduce fee cliff effects at utilisation boundaries.
     fn calculate_congestion_multiplier(pool: &LiquidityPool) -> u32 {
         if pool.total_liquidity == 0 {
             return 100;
@@ -370,7 +477,23 @@ impl LiquidityManager {
         }
     }
 
-    /// Calculate volume discount based on 24h volume
+    /// Calculate volume discount based on 24h volume.
+    ///
+    /// Iterates all configured discount tiers and returns the highest discount
+    /// whose threshold the user's 24-hour volume meets or exceeds.
+    ///
+    /// # Algorithm
+    ///
+    /// ```text
+    /// discount = max { tier_discount | threshold ≤ user_volume_24h }
+    /// ```
+    ///
+    /// Returns 0 if no tier is matched (volume below the lowest threshold).
+    ///
+    /// # Note
+    /// The tier map key is a `u32` threshold cast to `i128` for comparison.
+    /// Ensure tier thresholds are set in the same units as `user_volume_24h`
+    /// (token base units, not USD) to avoid mismatches.
     fn calculate_volume_discount(volume_tiers: &Map<u32, u32>, user_volume_24h: i128) -> u32 {
         let mut discount = 0u32;
 
@@ -384,8 +507,29 @@ impl LiquidityManager {
     }
 
     /// Calculate LP rewards based on position and pool performance.
-    /// Uses scaled arithmetic to avoid precision loss from integer division
-    /// truncating share_factor to zero for small positions.
+    ///
+    /// # Algorithm
+    ///
+    /// Uses scaled integer arithmetic to avoid precision loss from integer
+    /// division truncating `share_factor` to zero for small positions:
+    ///
+    /// ```text
+    /// reward = (position.amount * SCALE / total_liquidity) * position.amount / SCALE
+    ///        ≈ position.amount² / total_liquidity
+    /// ```
+    ///
+    /// where `SCALE = 1_000_000`.  This is mathematically equivalent to
+    /// `amount * (amount / total)` but avoids the inner division flooring to
+    /// zero when `amount << total`.
+    ///
+    /// # Note
+    /// This is a simplified proportional reward model.  In production, rewards
+    /// should also factor in time-in-pool and accumulated fee revenue.
+    ///
+    /// # TODO
+    /// - Integrate actual fee revenue collected by the pool so LP rewards
+    ///   reflect real earnings rather than a synthetic proportional amount.
+    /// - Add time-weighting: providers who stay longer earn a multiplier.
     fn calculate_lp_rewards(_env: &Env, position: &LPPosition, total_liquidity: i128) -> i128 {
         if total_liquidity == 0 || position.amount == 0 {
             return 0;

--- a/contracts/teachlink/src/reentrancy.rs
+++ b/contracts/teachlink/src/reentrancy.rs
@@ -1,10 +1,58 @@
+//! Reentrancy Guard Module
+//!
+//! Provides a storage-backed mutex to prevent reentrant calls within the same
+//! contract invocation. On Soroban, contract execution is single-threaded, but
+//! a contract can call itself indirectly through cross-contract invocations.
+//! This guard detects and blocks such recursive entry points.
+//!
+//! # Algorithm
+//!
+//! The guard uses a boolean flag stored in instance storage keyed by a caller-
+//! supplied `Symbol`. Before executing the protected closure:
+//!   1. Read the flag; if `true`, a reentrant call is in progress → return error.
+//!   2. Set the flag to `true` (acquire the lock).
+//!   3. Execute the closure and capture its result.
+//!   4. Set the flag back to `false` (release the lock), regardless of outcome.
+//!   5. Return the captured result.
+//!
+//! Because Soroban rolls back all storage writes on transaction failure, the flag
+//! is automatically cleared if the outer transaction aborts — no manual cleanup
+//! is needed.
+//!
+//! # Usage
+//!
+//! Each protected entry point should use a unique `Symbol` key so that
+//! independent operations do not block each other unnecessarily.
+//!
+//! ```ignore
+//! reentrancy::with_guard(env, &BRIDGE_GUARD, BridgeError::ReentrancyDetected, || {
+//!     // critical section
+//! })
+//! ```
+
 use soroban_sdk::{Env, Symbol};
 
+/// Executes `f` inside a reentrancy-protected critical section.
+///
+/// # Parameters
+/// - `env`              – Soroban environment reference.
+/// - `key`              – Unique storage key used as the mutex flag.
+/// - `reentrancy_error` – Error value returned when a reentrant call is detected.
+/// - `f`                – Closure containing the logic to protect.
+///
+/// # Returns
+/// The `Result` produced by `f`, or `Err(reentrancy_error)` if the guard is
+/// already active.
+///
+/// # TODO
+/// - Consider upgrading to a counter-based guard to support intentional
+///   recursive patterns (e.g., nested escrow releases) in future versions.
 pub fn with_guard<T, E, F>(env: &Env, key: &Symbol, reentrancy_error: E, f: F) -> Result<T, E>
 where
     E: Copy,
     F: FnOnce() -> Result<T, E>,
 {
+    // Step 1: Check if the guard is already active (reentrant call detected).
     let active = env
         .storage()
         .instance()
@@ -14,8 +62,17 @@ where
         return Err(reentrancy_error);
     }
 
+    // Step 2: Acquire the lock by setting the flag to true.
     env.storage().instance().set(key, &true);
+
+    // Step 3: Execute the protected closure.
     let result = f();
+
+    // Step 4: Release the lock unconditionally.
+    // NOTE: If `f` panics, Soroban aborts the transaction and rolls back all
+    // storage, so the flag is implicitly cleared. This explicit reset handles
+    // the non-panic `Err` path.
     env.storage().instance().set(key, &false);
+
     result
 }

--- a/contracts/teachlink/src/reputation.rs
+++ b/contracts/teachlink/src/reputation.rs
@@ -1,12 +1,74 @@
+//! User Reputation Module
+//!
+//! Tracks and updates the on-chain reputation of TeachLink users based on
+//! their learning activity and content contributions.
+//!
+//! # Reputation Components
+//!
+//! | Field                  | Description                                      |
+//! |------------------------|--------------------------------------------------|
+//! | `participation_score`  | Cumulative points from platform interactions     |
+//! | `completion_rate`      | Course completion ratio in basis points (0–10000)|
+//! | `contribution_quality` | Running average rating of submitted content (0–5)|
+//! | `total_courses_started`| Total courses the user has enrolled in           |
+//! | `total_courses_completed`| Total courses the user has finished            |
+//! | `total_contributions`  | Total content items rated                        |
+//!
+//! # Completion Rate Algorithm
+//!
+//! Stored in basis points (10 000 = 100 %) to avoid floating-point arithmetic:
+//!
+//! ```text
+//! completion_rate = (total_courses_completed * 10_000) / total_courses_started
+//! ```
+//!
+//! Recalculated on every `update_course_progress` call.  A guard ensures
+//! `total_courses_started >= total_courses_completed` to prevent impossible
+//! states when a completion event arrives before the corresponding start event.
+//!
+//! # Contribution Quality Algorithm
+//!
+//! Uses a cumulative running average (Welford-style without variance):
+//!
+//! ```text
+//! new_quality = (old_quality * old_count + new_rating) / new_count
+//! ```
+//!
+//! This avoids storing the full rating history while keeping the average
+//! accurate.  Ratings are on a 0–5 integer scale.
+//!
+//! # Storage
+//!
+//! Reputation data is stored in **persistent** storage (survives ledger
+//! expiry) keyed by `(REPUTATION, user_address)`.  This is intentional:
+//! reputation must not be lost due to TTL expiry.
+//!
+//! # TODO
+//! - Add a `credit_score` field derived from all three components with
+//!   configurable weights (see `score.rs`).
+//! - Consider capping `participation_score` to prevent overflow on very
+//!   active users (currently unbounded `u32`).
+
 use crate::events::{
     ContributionRatedEvent, CourseProgressUpdatedEvent, ParticipationUpdatedEvent,
 };
 use crate::types::UserReputation;
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
+/// Basis points divisor used for completion rate calculation (10 000 = 100 %).
 const BASIS_POINTS: u32 = 10000;
+
+/// Persistent storage key for user reputation records.
 const REPUTATION: Symbol = symbol_short!("reptn");
 
+/// Adds participation points to a user's reputation score.
+///
+/// Called by platform modules (e.g., forum posts, event attendance) to reward
+/// active engagement.  Points are additive and never decay automatically.
+///
+/// # TODO
+/// - Implement a time-decay factor so stale participation scores don't
+///   permanently dominate the credit score calculation.
 pub fn update_participation(env: &Env, user: Address, points: u32) {
     user.require_auth();
     let mut reputation = get_reputation(env, &user);
@@ -24,14 +86,34 @@ pub fn update_participation(env: &Env, user: Address, points: u32) {
     .publish(env);
 }
 
+/// Updates a user's course progress and recalculates their completion rate.
+///
+/// # Algorithm
+///
+/// - `is_completion = false`: increments `total_courses_started`.
+/// - `is_completion = true`: increments `total_courses_completed`.
+///   A guard ensures `total_courses_started >= total_courses_completed`
+///   to handle out-of-order events (e.g., completion recorded before start).
+///
+/// Completion rate is recalculated after every update:
+///
+/// ```text
+/// completion_rate = (total_courses_completed * 10_000) / total_courses_started
+/// ```
+///
+/// Stored in basis points to avoid floating-point arithmetic on-chain.
+///
+/// # TODO
+/// - Distinguish between "dropped" and "in-progress" courses so the
+///   completion rate reflects genuine finishes, not just enrollments.
 pub fn update_course_progress(env: &Env, user: Address, is_completion: bool) {
     user.require_auth();
     let mut reputation = get_reputation(env, &user);
 
     if is_completion {
         reputation.total_courses_completed += 1;
-        // Logic: You can't complete a course without starting it,
-        // but simple increment here assumes course started logic handled elsewhere or previously
+        // Guard: completion cannot exceed starts (handles out-of-order events).
+        // The course-started logic is assumed to be handled elsewhere or previously.
         if reputation.total_courses_started < reputation.total_courses_completed {
             reputation.total_courses_started = reputation.total_courses_completed;
         }
@@ -39,6 +121,7 @@ pub fn update_course_progress(env: &Env, user: Address, is_completion: bool) {
         reputation.total_courses_started += 1;
     }
 
+    // Recalculate completion rate in basis points.
     if reputation.total_courses_started > 0 {
         reputation.completion_rate =
             (reputation.total_courses_completed * BASIS_POINTS) / reputation.total_courses_started;
@@ -58,17 +141,42 @@ pub fn update_course_progress(env: &Env, user: Address, is_completion: bool) {
     .publish(env);
 }
 
+/// Records a quality rating for a user's contribution and updates their
+/// running average contribution quality score.
+///
+/// # Algorithm
+///
+/// Uses a cumulative running average to avoid storing the full rating history:
+///
+/// ```text
+/// new_quality = (old_quality * old_count + new_rating) / new_count
+/// ```
+///
+/// This is equivalent to the arithmetic mean of all ratings but requires
+/// only O(1) storage.
+///
+/// # Parameters
+/// - `rating` – Integer rating on a 0–5 scale.  Panics if > 5.
+///
+/// # Note
+/// The caller is the rater, not the rated user.  The `user` parameter is the
+/// content author whose reputation is being updated.  There is currently no
+/// check preventing self-rating — this should be enforced at the call site.
+///
+/// # TODO
+/// - Add a `rater: Address` parameter and enforce `rater != user` to prevent
+///   self-rating abuse.
+/// - Consider a weighted average where ratings from high-reputation users
+///   carry more weight.
 pub fn rate_contribution(env: &Env, user: Address, rating: u32) {
-    // Rating should be 0-5 scaled (e.g. 0-100 or 0-500)
-    // Here assuming 0-5
+    // Rating must be on the 0–5 integer scale.
     assert!(rating <= 5, "Rating must be between 0 and 5");
 
     let mut reputation = get_reputation(env, &user);
 
+    // Compute the new running average: (old_total + new_rating) / new_count.
     let current_total_quality = reputation.contribution_quality * reputation.total_contributions;
     reputation.total_contributions += 1;
-
-    // Weighted Average
     reputation.contribution_quality =
         (current_total_quality + rating) / reputation.total_contributions;
     reputation.last_update = env.ledger().timestamp();
@@ -86,6 +194,10 @@ pub fn rate_contribution(env: &Env, user: Address, rating: u32) {
     .publish(env);
 }
 
+/// Retrieves a user's reputation record from persistent storage.
+///
+/// Returns a zeroed `UserReputation` for users who have no record yet,
+/// so callers can safely read-modify-write without an existence check.
 pub fn get_reputation(env: &Env, user: &Address) -> UserReputation {
     env.storage()
         .persistent()
@@ -101,6 +213,10 @@ pub fn get_reputation(env: &Env, user: &Address) -> UserReputation {
         })
 }
 
+/// Persists a user's reputation record to storage.
+///
+/// Uses persistent storage so reputation survives ledger TTL expiry.
+/// The composite key `(REPUTATION, user)` namespaces records per user.
 fn set_reputation(env: &Env, user: &Address, reputation: &UserReputation) {
     env.storage()
         .persistent()

--- a/contracts/teachlink/src/slashing.rs
+++ b/contracts/teachlink/src/slashing.rs
@@ -2,6 +2,45 @@
 //!
 //! This module implements slashing mechanisms for malicious or negligent validators
 //! and reward distribution for honest validators.
+//!
+//! # Slashing Algorithm
+//!
+//! When a validator is slashed, the penalty is computed as a percentage of their
+//! current stake using basis-point arithmetic (10 000 bp = 100 %):
+//!
+//! ```text
+//! slash_amount = (stake * slash_percentage_bp) / 10_000
+//! ```
+//!
+//! Slashing percentages by offence type:
+//! | Reason              | Basis Points | Effective % |
+//! |---------------------|-------------|-------------|
+//! | DoubleVote          | 5 000       | 50 %        |
+//! | InvalidSignature    | 1 000       | 10 %        |
+//! | Inactivity          |   500       |  5 %        |
+//! | ByzantineBehavior   | 10 000      | 100 %       |
+//! | MaliciousProposal   | 10 000      | 100 %       |
+//!
+//! The slashed tokens are redirected into the shared reward pool so that honest
+//! validators benefit from penalising bad actors.
+//!
+//! # Reputation Decay
+//!
+//! Each slashing event also reduces the validator's `reputation_score`.  The
+//! decay amount mirrors the severity of the offence.  Reputation is clamped at
+//! zero to prevent underflow.
+//!
+//! # Inactivity Detection
+//!
+//! `check_inactivity` uses a dual-signal approach:
+//! 1. **Timestamp** – primary signal; inactive if `now - last_activity > 7 days`.
+//! 2. **Ledger sequence** – fallback for environments where `timestamp()` is
+//!    unreliable; converts the 7-day threshold to an approximate ledger delta
+//!    via `ledger_time::seconds_to_ledger_delta`.
+//!
+//! # Spec Reference
+//! See `contracts/documentation/TOKENIZATION.md` §Validator Economics for the
+//! economic rationale behind these percentages.
 
 use crate::errors::BridgeError;
 use crate::events::{
@@ -301,7 +340,30 @@ impl SlashingManager {
         Ok(())
     }
 
-    /// Check and slash inactive validators
+    /// Check and slash inactive validators.
+    ///
+    /// # Inactivity Detection Algorithm
+    ///
+    /// Uses a dual-signal approach to handle environments where `ledger().timestamp()`
+    /// may be unreliable (e.g., local test networks with frozen clocks):
+    ///
+    /// 1. **Primary – wall-clock timestamp**: inactive if
+    ///    `now - last_activity > INACTIVITY_THRESHOLD` (7 days).
+    /// 2. **Fallback – ledger sequence**: if the timestamp check passes, also
+    ///    verify using ledger sequence numbers converted to an approximate delta
+    ///    via `ledger_time::seconds_to_ledger_delta`.  This prevents false
+    ///    negatives on networks where time is not advancing.
+    ///
+    /// If inactivity is confirmed, `slash_validator` is called with
+    /// `SlashingReason::Inactivity` and the contract itself as the slasher
+    /// (self-enforcing rule, no external reporter needed).
+    ///
+    /// # Returns
+    /// `Ok(true)` if the validator was slashed, `Ok(false)` if still active.
+    ///
+    /// # TODO
+    /// - Add a grace period counter so a validator gets one warning before
+    ///   being slashed (reduces false positives from transient network issues).
     pub fn check_inactivity(env: &Env, validator: Address) -> Result<bool, BridgeError> {
         let validator_infos: Map<Address, ValidatorInfo> = env
             .storage()
@@ -358,7 +420,30 @@ impl SlashingManager {
         Ok(())
     }
 
-    /// Calculate new reputation score after slashing
+    /// Calculate new reputation score after slashing.
+    ///
+    /// # Algorithm
+    ///
+    /// Applies a fixed reputation penalty that scales with offence severity.
+    /// `saturating_sub` is used to clamp the result at zero, preventing
+    /// underflow on validators that have already been penalised heavily.
+    ///
+    /// Penalty table (reputation points deducted):
+    /// | Reason              | Penalty |
+    /// |---------------------|---------|
+    /// | DoubleVote          |  20     |
+    /// | InvalidSignature    |  10     |
+    /// | Inactivity          |   5     |
+    /// | ByzantineBehavior   |  50     |
+    /// | MaliciousProposal   | 100     |
+    ///
+    /// A validator starting at 100 reputation would be fully removed from the
+    /// active set (threshold: `MIN_ACTIVE_REPUTATION = 40`) after two
+    /// ByzantineBehavior slashes.
+    ///
+    /// # TODO
+    /// - Consider a time-based reputation recovery mechanism so validators can
+    ///   rehabilitate after a period of honest behaviour.
     fn calculate_new_reputation(current: u32, reason: &SlashingReason) -> u32 {
         let penalty = match reason {
             SlashingReason::DoubleVote => 20,

--- a/contracts/teachlink/src/types.rs
+++ b/contracts/teachlink/src/types.rs
@@ -1,6 +1,33 @@
 //! TeachLink Contract Types
 //!
 //! This module defines all data structures used throughout the TeachLink smart contract.
+//!
+//! # Type Categories
+//!
+//! - **Versioning** – `ContractSemVer`, `InterfaceVersionStatus`: semantic
+//!   versioning for contract interface compatibility checks.
+//! - **Chain Configuration** – `ChainConfig`, `MultiChainAsset`, `ChainAssetInfo`:
+//!   multi-chain bridge topology and asset mappings.
+//! - **BFT Consensus** – `ValidatorInfo`, `BridgeProposal`, `ConsensusState`:
+//!   validator registry and proposal voting state.
+//! - **Bridge** – `BridgeTransaction`, `CrossChainMessage`, `CrossChainPacket`:
+//!   cross-chain transfer lifecycle data.
+//! - **Liquidity** – `LiquidityPool`, `LPPosition`, `BridgeFeeStructure`:
+//!   AMM pool state and fee configuration.
+//! - **Escrow** – `Escrow`, `EscrowSigner`, `EscrowParameters`: multi-sig
+//!   escrow with dispute resolution.
+//! - **Tokenization** – `ContentToken`, `ContentMetadata`, `ProvenanceRecord`:
+//!   educational content NFTs and ownership history.
+//! - **Reputation** – `UserReputation`: participation, completion, and
+//!   contribution quality scores.
+//! - **Notifications** – `NotificationTemplate`, `NotificationTracking`,
+//!   `UserNotificationSettings`: multi-channel notification system.
+//!
+//! # Arithmetic Safety
+//!
+//! `ContractSemVer` comparison uses tuple ordering to avoid multi-field
+//! conditional chains.  All monetary fields use `i128` to match Soroban's
+//! native token amount type and avoid implicit truncation.
 
 use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, Map, String, Symbol, Vec};
 
@@ -27,11 +54,19 @@ impl ContractSemVer {
         }
     }
 
+    /// Returns `true` if this version is strictly lower than `other`.
+    ///
+    /// Uses tuple comparison `(major, minor, patch)` which applies
+    /// lexicographic ordering — the same semantics as SemVer:
+    /// major takes precedence, then minor, then patch.
     #[must_use]
     pub fn is_lower_than(&self, other: &Self) -> bool {
         (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
     }
 
+    /// Returns `true` if this version is strictly greater than `other`.
+    ///
+    /// See `is_lower_than` for the comparison semantics.
     #[must_use]
     pub fn is_greater_than(&self, other: &Self) -> bool {
         (self.major, self.minor, self.patch) > (other.major, other.minor, other.patch)

--- a/contracts/teachlink/src/validation.rs
+++ b/contracts/teachlink/src/validation.rs
@@ -2,22 +2,44 @@ use crate::errors::EscrowError;
 use crate::types::EscrowSigner;
 use soroban_sdk::{Address, Bytes, Env, String, Vec};
 
-/// Validation configuration constants
+/// Validation configuration constants.
+///
+/// Centralising limits here makes it easy to adjust bounds without hunting
+/// through business logic.  All monetary amounts are in token base units
+/// (smallest indivisible unit, e.g. stroops for XLM).
 pub mod config {
+    /// Minimum transfer/escrow amount (1 base unit — prevents dust attacks).
     pub const MIN_AMOUNT: i128 = 1;
+    /// Maximum transfer/escrow amount — set to half of i128::MAX to leave
+    /// headroom for fee addition without overflow.
     pub const MAX_AMOUNT: i128 = i128::MAX / 2; // Prevent overflow
+    /// Minimum number of escrow signers (at least one required).
     pub const MIN_SIGNERS: u32 = 1;
+    /// Maximum number of escrow signers (prevents unbounded iteration cost).
     pub const MAX_SIGNERS: u32 = 100;
+    /// Minimum approval threshold (must require at least one signer).
     pub const MIN_THRESHOLD: u32 = 1;
+    /// Maximum string length for titles, descriptions, etc.
     pub const MAX_STRING_LENGTH: u32 = 256;
+    /// Minimum valid chain ID (0 is reserved as "unset").
     pub const MIN_CHAIN_ID: u32 = 1;
+    /// Maximum valid chain ID (supports up to ~1 million chains).
     pub const MAX_CHAIN_ID: u32 = 999999;
+    /// Maximum escrow description length (longer than general strings to
+    /// accommodate detailed payment terms).
     pub const MAX_ESCROW_DESCRIPTION_LENGTH: u32 = 1000;
+    /// Minimum timeout duration (1 minute — prevents immediately-expired locks).
     pub const MIN_TIMEOUT_SECONDS: u64 = 60; // 1 minute minimum
+    /// Maximum timeout duration (10 years — prevents effectively-permanent locks).
     pub const MAX_TIMEOUT_SECONDS: u64 = 31536000 * 10; // 10 years maximum
+    /// Maximum cross-chain packet payload size (4 KB — balances expressiveness
+    /// with on-chain storage cost).
     pub const MAX_PAYLOAD_SIZE: u32 = 4096; // 4 KB max packet payload
-    /// Bridge-specific amount bounds
+    /// Bridge-specific minimum amount (same as MIN_AMOUNT, kept separate for
+    /// independent tuning).
     pub const MIN_BRIDGE_AMOUNT: i128 = 1;
+    /// Bridge-specific maximum amount (1e18 base units — ~1 billion tokens
+    /// with 9 decimals; prevents single transactions from draining the pool).
     pub const MAX_BRIDGE_AMOUNT: i128 = 1_000_000_000_000_000_000; // 1e18
 }
 


### PR DESCRIPTION
Closes #372
Adds inline documentation across all key contract modules.

- reentrancy.rs – storage-backed mutex algorithm, lock/unlock flow
- bft_consensus.rs – BFT threshold formula, dual-signal expiry, voting algorithm
- slashing.rs – slashing percentage table, reputation decay, inactivity detection
- liquidity.rs – 3-stage fee formula, congestion multiplier, LP reward algorithm
- atomic_swap.rs – HTLC protocol flow, timelock dual-signal, hashlock verification
- reputation.rs – completion rate basis-points, running average contribution quality
- validation.rs – config constants with rationale
- audit.rs – circular buffer design
- errors.rs – error code range table
- types.rs – type category overview
- documentation/src/lib.rs – storage model, overflow protection, search stub TODO



