### PR TITLE
refactor: consolidate duplicate validation logic across modules

### DIFF
--- a/contracts/teachlink/src/lib.rs
+++ b/contracts/teachlink/src/lib.rs
@@ -163,6 +163,12 @@ mod validation;
 // TODO: Fix validation_tests compilation errors (pre-existing issue)
 // mod validation_tests;
 
+pub use validation::{
+    config, AddressValidator, BridgeValidator, BytesValidator, CrossChainValidator,
+    EscrowValidator, InputSanitizer, NumberValidator, RewardsValidator, StringValidator,
+    ValidationError, ValidationResult,
+};
+
 pub use crate::types::{
     ColorBlindMode, ComponentConfig, DeviceInfo, FeedbackCategory, FocusStyle, FontSize,
     LayoutDensity, MobileAccessibilitySettings, MobilePreferences, MobileProfile, NetworkType,

--- a/contracts/teachlink/src/liquidity.rs
+++ b/contracts/teachlink/src/liquidity.rs
@@ -62,8 +62,7 @@ impl LiquidityManager {
     ) -> Result<u32, BridgeError> {
         provider.require_auth();
 
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env
@@ -131,8 +130,7 @@ impl LiquidityManager {
     ) -> Result<i128, BridgeError> {
         provider.require_auth();
 
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env
@@ -198,8 +196,7 @@ impl LiquidityManager {
 
     /// Lock liquidity for a bridge transaction
     pub fn lock_liquidity(env: &Env, chain_id: u32, amount: i128) -> Result<(), BridgeError> {
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env
@@ -229,8 +226,7 @@ impl LiquidityManager {
 
     /// Unlock liquidity after bridge completion
     pub fn unlock_liquidity(env: &Env, chain_id: u32, amount: i128) -> Result<(), BridgeError> {
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env

--- a/contracts/teachlink/src/liquidity.rs
+++ b/contracts/teachlink/src/liquidity.rs
@@ -7,6 +7,7 @@ use crate::errors::BridgeError;
 use crate::events::{FeeUpdatedEvent, LiquidityAddedEvent, LiquidityRemovedEvent};
 use crate::storage::{FEE_STRUCTURE, LIQUIDITY_POOLS, LP_POSITIONS};
 use crate::types::{BridgeFeeStructure, LPPosition, LiquidityPool};
+use crate::validation::NumberValidator;
 use soroban_sdk::{Address, Env, Map, Vec};
 
 /// Base fee in basis points (0.1%)
@@ -61,9 +62,8 @@ impl LiquidityManager {
     ) -> Result<u32, BridgeError> {
         provider.require_auth();
 
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env
@@ -131,9 +131,8 @@ impl LiquidityManager {
     ) -> Result<i128, BridgeError> {
         provider.require_auth();
 
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env
@@ -199,9 +198,8 @@ impl LiquidityManager {
 
     /// Lock liquidity for a bridge transaction
     pub fn lock_liquidity(env: &Env, chain_id: u32, amount: i128) -> Result<(), BridgeError> {
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env
@@ -231,9 +229,8 @@ impl LiquidityManager {
 
     /// Unlock liquidity after bridge completion
     pub fn unlock_liquidity(env: &Env, chain_id: u32, amount: i128) -> Result<(), BridgeError> {
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get pool
         let mut pools: Map<u32, LiquidityPool> = env

--- a/contracts/teachlink/src/multichain.rs
+++ b/contracts/teachlink/src/multichain.rs
@@ -7,6 +7,7 @@ use crate::errors::BridgeError;
 use crate::events::{AssetRegisteredEvent, ChainAddedEvent, ChainUpdatedEvent};
 use crate::storage::{ASSET_COUNTER, CHAIN_CONFIGS, MULTI_CHAIN_ASSETS, SUPPORTED_CHAINS};
 use crate::types::{ChainAssetInfo, ChainConfig, MultiChainAsset};
+use crate::validation::NumberValidator;
 use soroban_sdk::{Address, Bytes, Env, Map, Vec};
 
 /// Maximum number of supported chains
@@ -238,9 +239,8 @@ impl MultiChainManager {
         amount: i128,
         is_outgoing: bool,
     ) -> Result<(), BridgeError> {
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         let mut assets: Map<u64, MultiChainAsset> = env
             .storage()

--- a/contracts/teachlink/src/multichain.rs
+++ b/contracts/teachlink/src/multichain.rs
@@ -239,8 +239,7 @@ impl MultiChainManager {
         amount: i128,
         is_outgoing: bool,
     ) -> Result<(), BridgeError> {
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         let mut assets: Map<u64, MultiChainAsset> = env
             .storage()

--- a/contracts/teachlink/src/slashing.rs
+++ b/contracts/teachlink/src/slashing.rs
@@ -7,12 +7,12 @@ use crate::errors::BridgeError;
 use crate::events::{
     StakeDepositedEvent, StakeWithdrawnEvent, ValidatorRewardedEvent, ValidatorSlashedEvent,
 };
-use crate::validation::{NumberValidator, ValidationError};
 use crate::storage::{
     REWARD_POOL, SLASHING_COUNTER, SLASHING_RECORDS, VALIDATOR_ACTIVITY_SEQ, VALIDATOR_INFO,
     VALIDATOR_REWARDS, VALIDATOR_STAKES,
 };
 use crate::types::{RewardType, SlashingReason, SlashingRecord, ValidatorInfo, ValidatorReward};
+use crate::validation::{NumberValidator, ValidationError};
 use soroban_sdk::{Address, Env, Map, Vec};
 
 /// Slashing percentages (in basis points, 10000 = 100%)
@@ -36,8 +36,7 @@ impl SlashingManager {
     pub fn deposit_stake(env: &Env, validator: Address, amount: i128) -> Result<(), BridgeError> {
         validator.require_auth();
 
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get current stake
         let mut stakes: Map<Address, i128> = env
@@ -81,8 +80,7 @@ impl SlashingManager {
     pub fn withdraw_stake(env: &Env, validator: Address, amount: i128) -> Result<(), BridgeError> {
         validator.require_auth();
 
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get current stake
         let mut stakes: Map<Address, i128> = env
@@ -239,8 +237,7 @@ impl SlashingManager {
         amount: i128,
         reward_type: RewardType,
     ) -> Result<(), BridgeError> {
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Check reward pool
         let reward_pool: i128 = env.storage().instance().get(&REWARD_POOL).unwrap_or(0i128);
@@ -345,8 +342,7 @@ impl SlashingManager {
     pub fn fund_reward_pool(env: &Env, funder: Address, amount: i128) -> Result<(), BridgeError> {
         funder.require_auth();
 
-        NumberValidator::validate_amount(amount)
-            .map_err(|_| BridgeError::AmountMustBePositive)?;
+        NumberValidator::validate_amount(amount).map_err(|_| BridgeError::AmountMustBePositive)?;
 
         let reward_pool: i128 = env.storage().instance().get(&REWARD_POOL).unwrap_or(0i128);
         let new_balance = reward_pool + amount;

--- a/contracts/teachlink/src/slashing.rs
+++ b/contracts/teachlink/src/slashing.rs
@@ -7,6 +7,7 @@ use crate::errors::BridgeError;
 use crate::events::{
     StakeDepositedEvent, StakeWithdrawnEvent, ValidatorRewardedEvent, ValidatorSlashedEvent,
 };
+use crate::validation::{NumberValidator, ValidationError};
 use crate::storage::{
     REWARD_POOL, SLASHING_COUNTER, SLASHING_RECORDS, VALIDATOR_ACTIVITY_SEQ, VALIDATOR_INFO,
     VALIDATOR_REWARDS, VALIDATOR_STAKES,
@@ -35,9 +36,8 @@ impl SlashingManager {
     pub fn deposit_stake(env: &Env, validator: Address, amount: i128) -> Result<(), BridgeError> {
         validator.require_auth();
 
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get current stake
         let mut stakes: Map<Address, i128> = env
@@ -81,9 +81,8 @@ impl SlashingManager {
     pub fn withdraw_stake(env: &Env, validator: Address, amount: i128) -> Result<(), BridgeError> {
         validator.require_auth();
 
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Get current stake
         let mut stakes: Map<Address, i128> = env
@@ -240,9 +239,8 @@ impl SlashingManager {
         amount: i128,
         reward_type: RewardType,
     ) -> Result<(), BridgeError> {
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         // Check reward pool
         let reward_pool: i128 = env.storage().instance().get(&REWARD_POOL).unwrap_or(0i128);
@@ -347,9 +345,8 @@ impl SlashingManager {
     pub fn fund_reward_pool(env: &Env, funder: Address, amount: i128) -> Result<(), BridgeError> {
         funder.require_auth();
 
-        if amount <= 0 {
-            return Err(BridgeError::AmountMustBePositive);
-        }
+        NumberValidator::validate_amount(amount)
+            .map_err(|_| BridgeError::AmountMustBePositive)?;
 
         let reward_pool: i128 = env.storage().instance().get(&REWARD_POOL).unwrap_or(0i128);
         let new_balance = reward_pool + amount;


### PR DESCRIPTION
- Replace inline amount validation (if amount <= 0) with shared NumberValidator::validate_amount()
- Refactor slashing.rs: deposit_stake, withdraw_stake, reward_validator, fund_reward_pool
- Refactor multichain.rs: update_bridged_amount
- Refactor liquidity.rs: add_liquidity, remove_liquidity, lock_liquidity, unlock_liquidity
- Export validation module for external use via lib.rs
- Reduces code duplication and improves maintainability

closes: #362 